### PR TITLE
RDISCROWD-1407 Allow users to edit their own metadata when enforce_privacy is on.

### DIFF
--- a/templates/account/public_profile.html
+++ b/templates/account/public_profile.html
@@ -9,7 +9,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-offset-2 col-md-8" style="margin-top:30px;">
-                {% if enforce_privacy and (current_user.is_anonymous() or (current_user.is_authenticated and not current_user.admin and not current_user.subadmin)) %}
+                {% if enforce_privacy and (current_user.is_anonymous() or not (current_user.admin or current_user.subadmin or current_user.id == user.id)) %}
                 {{ privacy.render_lock_page() }}
                 {% else %}
                 <div class="text-center" style="margin-top:30px;">


### PR DESCRIPTION
I removed the `current_user.is_authenticated` since it was wrong to call it as a property get, and it wasn't needed anyway.