### PR TITLE
change UI to hide consensus-config when retry is not checked

### DIFF
--- a/static/src/components/fieldsconfig/field_config_base.vue
+++ b/static/src/components/fieldsconfig/field_config_base.vue
@@ -27,7 +27,6 @@
           </span>
           <span
             v-if="retry"
-            type="button"
             class="btn btn-sm btn-default"
             @click="changeRetryStatus"
           >
@@ -35,7 +34,6 @@
           </span>
           <span
             v-else
-            type="button"
             class="btn btn-sm btn-success"
             @click="changeRetryStatus"
           >

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -1,20 +1,13 @@
 <template>
   <div class="stats-config row">
     <div class="col-md-12">
+      <h3> Answer Field Configuration </h3>
       <div
         class="form-group"
         :class="{'has-error': error}"
       >
         <div class="row">
-          <div class="col-md-7">
-            <p> Path to answer field: </p>
-            <input
-              v-model="fieldName"
-              type="text"
-              class="form-control"
-            >
-          </div>
-          <div class="col-md-5 pull-right">
+          <div class="col-md-5">
             <p> Type of answer </p>
             <select
               v-model="fieldType"
@@ -30,10 +23,18 @@
               </option>
             </select>
           </div>
+          <div class="col-md-7  pull-right">
+            <p> Answer field path: </p>
+            <input
+              v-model="fieldName"
+              type="text"
+              class="form-control"
+              :v-bind:title="message1"
+            >
+          </div>
         </div>
-
         <div class="checkbox">
-          <label>
+          <label :v-bind:title="message2">
             <input
               v-model="retryForConsensus"
               type="checkbox"
@@ -82,6 +83,7 @@
         </div>
       </div>
       <button
+        :disabled="hasRetryFields && !hasConsensusConfig"
         class="btn btn-primary"
         @click="save"
       >
@@ -92,6 +94,7 @@
 </template>
 
 <script>
+
 import { mapGetters, mapMutations } from 'vuex';
 import FieldConfigBase from './field_config_base';
 import CategoricalFieldConfig from './categorical_field_config';
@@ -110,12 +113,14 @@ export default {
       fieldType: labelTypes.default,
       retryForConsensus: false,
       error: false,
-      labelTypes
+      labelTypes,
+      message1: 'This should match "pyb-answer" in your task presenter',
+      message2: 'Consensus configuration must be filled out to enable retry feature'
     };
   },
 
   computed: {
-    ...mapGetters(['answerFields', 'csrfToken', 'isNewField'])
+    ...mapGetters(['answerFields', 'csrfToken', 'isNewField', 'hasConsensusConfig', 'hasRetryFields'])
   },
 
   methods: {
@@ -141,6 +146,7 @@ export default {
       this.fieldType = labelTypes.default;
       this.retryForConsensus = false;
     },
+
     async save () {
       try {
         const res = await fetch(window.location.pathname, {
@@ -159,8 +165,6 @@ export default {
           window.pybossaNotify('An error occurred.', true, 'error');
         }
       } catch (error) {
-        console.warn(error);
-        console.log('an error occurred');
         window.pybossaNotify('An error occurred.', true, 'error');
       }
     }
@@ -179,5 +183,15 @@ export default {
   max-height: 600px;
   overflow-y: scroll;
   margin-bottom: 20px;
+}
+.tooltip-inner {
+  max-width: 350px !important;
+  font-size: 15px;
+  padding: 10px 15px 10px 20px;
+  background: #ffffff;
+  color: rgb(0, 0, 0, .7);
+  border: 1px snow #737373;
+  text-align: left;
+  opacity: 1;
 }
 </style>

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -29,12 +29,12 @@
               v-model="fieldName"
               type="text"
               class="form-control"
-              :v-bind:title="message1"
+              :title="message1"
             >
           </div>
         </div>
         <div class="checkbox">
-          <label :v-bind:title="message2">
+          <label :title="message2">
             <input
               v-model="retryForConsensus"
               type="checkbox"

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -184,14 +184,4 @@ export default {
   overflow-y: scroll;
   margin-bottom: 20px;
 }
-.tooltip-inner {
-  max-width: 350px !important;
-  font-size: 15px;
-  padding: 10px 15px 10px 20px;
-  background: #ffffff;
-  color: rgb(0, 0, 0, .7);
-  border: 1px snow #737373;
-  text-align: left;
-  opacity: 1;
-}
 </style>

--- a/static/src/components/fieldsconfig/store.js
+++ b/static/src/components/fieldsconfig/store.js
@@ -70,8 +70,9 @@ const storeSpecs = {
       const ix = state.fieldNames.indexOf(name);
       if (ix >= 0) {
         state.fieldNames.splice(ix, 1);
+        state.answerFields[name].retryForConsensus = false;
       }
-      state.answerFields[name].retryForConsensus = false;
+
       delete state.answerFields[name];
     },
 

--- a/static/src/test/components/fieldsconfig/consensus_config.spec.js
+++ b/static/src/test/components/fieldsconfig/consensus_config.spec.js
@@ -20,20 +20,66 @@ describe('ConsensusConfig', () => {
     notify = window.pybossaNotify = jest.fn();
   });
 
+  it('does not load data', () => {
+    store.commit('setData', {
+      answerFields: {
+        testField: {
+          type: 'categorical',
+          config: {
+            labels: ['A', 'B', 'C']
+          },
+          retryForConsensus: false
+        }
+      },
+      consensus: { }
+    });
+    const wrapper = mount(ConsensusConfig, { store, localVue });
+    const p = wrapper.findAll('p');
+    expect(p).toHaveLength(0);
+  })
+
   it('loads empty config', () => {
-    const wrapper = mount(ConsensusConfig);
+    store.commit('setData', {
+      answerFields: {
+        testField: {
+          type: 'categorical',
+          config: {
+            labels: ['A', 'B', 'C']
+          },
+          retryForConsensus: true
+        }
+      },
+      consensus: { }
+    });
+    const wrapper = mount(ConsensusConfig, { store, localVue });
     const p = wrapper.findAll('p').at(3);
     expect(p.text()).toEqual('No consensus currently configured.');
   });
 
   it('load non-empty config', () => {
-    const wrapper = mount(ConsensusConfig, {
-      propsData: {
-        consensusConfig: { threshold: 70, maxRetries: 10, redundancyDelta: 1 }
+    const propsData = {
+      consensusConfig: { threshold: 70, maxRetries: 10, redundancyDelta: 1 }
+    };
+    store.commit('setData', {
+      answerFields: {
+        testField: {
+          type: 'categorical',
+          config: {
+            labels: ['A', 'B', 'C']
+          },
+          retryForConsensus: true
+        }
+      },
+      consensus: {
+        threshold: 70,
+        maxRetries: 10,
+        redundancyDelta: 1
       }
     });
-    wrapper.setProps({ 'consensusConfig': { threshold: 70, maxRetries: 10, redundancyDelta: 1 } });
+    const wrapper = mount(ConsensusConfig, { store, localVue, propsData });
     const p = wrapper.findAll('p');
+    const button = wrapper.findAll('button');
+    expect(button).toHaveLength(2);
     expect(p).toHaveLength(9);
   });
 
@@ -42,10 +88,57 @@ describe('ConsensusConfig', () => {
       ok: true,
       json: () => Promise.resolve({ flash: 'hello', status: 'success' })
     }));
+    store.commit('setData', {
+      answerFields: {
+        testField: {
+          type: 'categorical',
+          config: {
+            labels: ['A', 'B', 'C']
+          },
+          retryForConsensus: true
+        }
+      }
+    });
     const wrapper = mount(ConsensusConfig, { store, localVue });
     wrapper.setData({ threshold: 80, maxRetries: 15, redundancyDelta: 3 });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
+    await localVue.nextTick();
+    expect(fetch.mock.calls).toHaveLength(1);
+    expect(notify.mock.calls).toHaveLength(1);
+    const [ msg, dismissable, status ] = notify.mock.calls[0];
+    expect(msg).toBe('hello');
+    expect(dismissable).toBe(true);
+    expect(status).toBe('success');
+  });
+
+  it('delete config', async () => {
+    fetch.mockImplementation((arg) => ({
+      ok: true,
+      json: () => Promise.resolve({ flash: 'hello', status: 'success' })
+    }));
+    const propsData = {
+      consensusConfig: { threshold: 70, maxRetries: 10, redundancyDelta: 1 }
+    };
+    store.commit('setData', {
+      answerFields: {
+        testField: {
+          type: 'categorical',
+          config: {
+            labels: ['A', 'B', 'C']
+          },
+          retryForConsensus: true
+        }
+      },
+      consensus: {
+        threshold: 70,
+        maxRetries: 10,
+        redundancyDelta: 1
+      }
+    });
+    const wrapper = mount(ConsensusConfig, { store, localVue, propsData });
+    const deleteButton = wrapper.findAll('button').at(1);
+    deleteButton.trigger('click');
     await localVue.nextTick();
     expect(fetch.mock.calls).toHaveLength(1);
     expect(notify.mock.calls).toHaveLength(1);

--- a/static/src/test/components/fieldsconfig/consensus_config.spec.js
+++ b/static/src/test/components/fieldsconfig/consensus_config.spec.js
@@ -36,7 +36,7 @@ describe('ConsensusConfig', () => {
     const wrapper = mount(ConsensusConfig, { store, localVue });
     const p = wrapper.findAll('p');
     expect(p).toHaveLength(0);
-  })
+  });
 
   it('loads empty config', () => {
     store.commit('setData', {

--- a/static/src/test/components/fieldsconfig/index.spec.js
+++ b/static/src/test/components/fieldsconfig/index.spec.js
@@ -41,7 +41,7 @@ describe('fieldsconfig', () => {
     const fields = wrapper.findAll('.field-config');
     expect(fields.length).toEqual(1);
     const field = fields.at(0);
-    expect(field.text()).toContain('Categorical Field - testField');
+    expect(field.text()).toContain('Categorical Field - testfield');
   });
 
   it('shows error if name is empty', () => {

--- a/static/src/test/components/fieldsconfig/store.spec.js
+++ b/static/src/test/components/fieldsconfig/store.spec.js
@@ -25,7 +25,7 @@ describe('fieldsconfig', () => {
       }
     });
     expect(store.state.fieldNames).toHaveLength(1);
-    expect(store.state.fieldNames[0]).toBe('testField');
+    expect(store.state.fieldNames[0]).toBe('testfield');
   });
 
   it('does not delete invalid fields', () => {

--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -1,30 +1,84 @@
-{% extends "projects/base.html" %}
-{% set active_page = "projects" %}
-{% set active_link  = "settings" %}
-{% set section = _('Configuration') %}
-{% from "_formhelpers.html" import render_form %}
-
-{% block projectcontent %}
-
-<div id="answerfieldsconfig">
-    <div class="row">
-        <div class="col-md-5">
-            <h3> Consensus Configuration </h3>
-            <consensus-config :consensus-config="{{consensus_config}}"></consensus-config>
-        </div>
-        <div class="col-md-7 pull-right">
-            <h3> Answer Field Configuration </h3>
-            <fields-config></fields-config>
-        </div>
-    </div>
-</div>
-
-<script src="/static/js/gen/answerfieldsconfig.min.5f5a2083d51e71cb3b88.js"></script>
-
-<script>
-answerFields.setData({
-    csrf: '{{csrf}}',
-    answerFields: {{answer_fields | safe}}
-});
-</script>
-{% endblock %}
+Html Webpack Plugin:
+<pre>
+  Error: Child compilation failed:
+  Module build failed: Error: ENOENT: no such file or directory, open '/Users/wyuan35/work/pybossa/pybossa/themes/default/static/src/node_modules/lodash/lodash.js':
+  Error: ENOENT: no such file or directory, open '/Users/wyuan35/work/pybossa/pybossa/themes/default/static/src/node_modules/lodash/lodash.js'
+  
+  - compiler.js:79 childCompiler.runAsChild
+    [src]/[html-webpack-plugin]/lib/compiler.js:79:16
+  
+  - Compiler.js:306 compile
+    [src]/[webpack]/lib/Compiler.js:306:11
+  
+  - Compiler.js:631 hooks.afterCompile.callAsync.err
+    [src]/[webpack]/lib/Compiler.js:631:15
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compiler.js:628 compilation.seal.err
+    [src]/[webpack]/lib/Compiler.js:628:31
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compilation.js:1329 hooks.optimizeAssets.callAsync.err
+    [src]/[webpack]/lib/Compilation.js:1329:35
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compilation.js:1320 hooks.optimizeChunkAssets.callAsync.err
+    [src]/[webpack]/lib/Compilation.js:1320:32
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compilation.js:1315 hooks.additionalAssets.callAsync.err
+    [src]/[webpack]/lib/Compilation.js:1315:36
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compilation.js:1311 hooks.optimizeTree.callAsync.err
+    [src]/[webpack]/lib/Compilation.js:1311:32
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compilation.js:1248 Compilation.seal
+    [src]/[webpack]/lib/Compilation.js:1248:27
+  
+  - Compiler.js:625 compilation.finish.err
+    [src]/[webpack]/lib/Compiler.js:625:18
+  
+  - Compilation.js:1171 hooks.finishModules.callAsync.err
+    [src]/[webpack]/lib/Compilation.js:1171:4
+  
+  
+  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
+    [src]/[tapable]/lib/Hook.js:154:20
+  
+  - Compilation.js:1163 Compilation.finish
+    [src]/[webpack]/lib/Compilation.js:1163:28
+  
+  - Compiler.js:622 hooks.make.callAsync.err
+    [src]/[webpack]/lib/Compiler.js:622:17
+  
+  
+  - Compilation.js:1095 _addModuleChain
+    [src]/[webpack]/lib/Compilation.js:1095:12
+  
+  - Compilation.js:1007 processModuleDependencies.err
+    [src]/[webpack]/lib/Compilation.js:1007:9
+  
+  - task_queues.js:79 processTicksAndRejections
+    internal/process/task_queues.js:79:9
+  
+</pre>

--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -17,7 +17,7 @@
     </div>
 </div>
 
-<script src="/static/js/gen/answerfieldsconfig.min.5edcbae031753080d664.js"></script>
+<script src="/static/js/gen/answerfieldsconfig.min.7d1877ae89321fcda728.js"></script>
 
 <script>
 answerFields.setData({

--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -1,84 +1,29 @@
-Html Webpack Plugin:
-<pre>
-  Error: Child compilation failed:
-  Module build failed: Error: ENOENT: no such file or directory, open '/Users/wyuan35/work/pybossa/pybossa/themes/default/static/src/node_modules/lodash/lodash.js':
-  Error: ENOENT: no such file or directory, open '/Users/wyuan35/work/pybossa/pybossa/themes/default/static/src/node_modules/lodash/lodash.js'
-  
-  - compiler.js:79 childCompiler.runAsChild
-    [src]/[html-webpack-plugin]/lib/compiler.js:79:16
-  
-  - Compiler.js:306 compile
-    [src]/[webpack]/lib/Compiler.js:306:11
-  
-  - Compiler.js:631 hooks.afterCompile.callAsync.err
-    [src]/[webpack]/lib/Compiler.js:631:15
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compiler.js:628 compilation.seal.err
-    [src]/[webpack]/lib/Compiler.js:628:31
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compilation.js:1329 hooks.optimizeAssets.callAsync.err
-    [src]/[webpack]/lib/Compilation.js:1329:35
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compilation.js:1320 hooks.optimizeChunkAssets.callAsync.err
-    [src]/[webpack]/lib/Compilation.js:1320:32
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compilation.js:1315 hooks.additionalAssets.callAsync.err
-    [src]/[webpack]/lib/Compilation.js:1315:36
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compilation.js:1311 hooks.optimizeTree.callAsync.err
-    [src]/[webpack]/lib/Compilation.js:1311:32
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compilation.js:1248 Compilation.seal
-    [src]/[webpack]/lib/Compilation.js:1248:27
-  
-  - Compiler.js:625 compilation.finish.err
-    [src]/[webpack]/lib/Compiler.js:625:18
-  
-  - Compilation.js:1171 hooks.finishModules.callAsync.err
-    [src]/[webpack]/lib/Compilation.js:1171:4
-  
-  
-  - Hook.js:154 AsyncSeriesHook.lazyCompileHook
-    [src]/[tapable]/lib/Hook.js:154:20
-  
-  - Compilation.js:1163 Compilation.finish
-    [src]/[webpack]/lib/Compilation.js:1163:28
-  
-  - Compiler.js:622 hooks.make.callAsync.err
-    [src]/[webpack]/lib/Compiler.js:622:17
-  
-  
-  - Compilation.js:1095 _addModuleChain
-    [src]/[webpack]/lib/Compilation.js:1095:12
-  
-  - Compilation.js:1007 processModuleDependencies.err
-    [src]/[webpack]/lib/Compilation.js:1007:9
-  
-  - task_queues.js:79 processTicksAndRejections
-    internal/process/task_queues.js:79:9
-  
-</pre>
+{% extends "projects/base.html" %}
+{% set active_page = "projects" %}
+{% set active_link  = "settings" %}
+{% set section = _('Configuration') %}
+{% from "_formhelpers.html" import render_form %}
+
+{% block projectcontent %}
+
+<div id="answerfieldsconfig">
+    <div class="row">
+        <div class="col-md-7">
+            <fields-config></fields-config>
+        </div>
+        <div class="col-md-5 pull-right">
+            <consensus-config :consensus-config="{{consensus_config}}"></consensus-config>
+        </div>
+    </div>
+</div>
+
+<script src="/static/js/gen/answerfieldsconfig.min.5edcbae031753080d664.js"></script>
+
+<script>
+answerFields.setData({
+    csrf: '{{csrf}}',
+    answerFields: {{answer_fields | safe}},
+    consensus: {{consensus_config | safe}}
+});
+</script>
+{% endblock %}

--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -17,7 +17,7 @@
     </div>
 </div>
 
-<script src="/static/js/gen/answerfieldsconfig.min.7d1877ae89321fcda728.js"></script>
+<script src="/static/js/gen/answerfieldsconfig.min.7feadaf2660c97dcd139.js"></script>
 
 <script>
 answerFields.setData({

--- a/templates/projects/answerfieldsconfig.webpack.ejs
+++ b/templates/projects/answerfieldsconfig.webpack.ejs
@@ -8,13 +8,11 @@
 
 <div id="answerfieldsconfig">
     <div class="row">
-        <div class="col-md-5">
-            <h3> Consensus Configuration </h3>
-            <consensus-config :consensus-config="{{consensus_config}}"></consensus-config>
-        </div>
-        <div class="col-md-7 pull-right">
-            <h3> Answer Field Configuration </h3>
+        <div class="col-md-7">
             <fields-config></fields-config>
+        </div>
+        <div class="col-md-5 pull-right">
+            <consensus-config :consensus-config="{{consensus_config}}"></consensus-config>
         </div>
     </div>
 </div>
@@ -24,7 +22,8 @@
 <script>
 answerFields.setData({
     csrf: '{{csrf}}',
-    answerFields: {{answer_fields | safe}}
+    answerFields: {{answer_fields | safe}},
+    consensus: {{consensus_config | safe}}
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
Changes: 

- shows consensus-config only if at least one answer field opt in "Retry".

- disable the "Save" button of answer fields config when at least one answer field opt in "Retry" but consensus-config is empty

- Add instruction tooltip on "answer field path" input box and "Retry" check box

Please review, thanks.