### PR TITLE
RDISCROWD-1635: Disable updating a Gold task for non-owners of a project

### DIFF
--- a/static/css/task_browse.css
+++ b/static/css/task_browse.css
@@ -32,6 +32,10 @@
 #tasksGrid th.sortable {
     cursor: pointer;
 }
+#tasksGrid .gold-task {
+    display: block;
+    margin: 0 0.25rem;
+}
 #date_from {
     z-index: 1051;
 }

--- a/static/js/tasks_browse.js
+++ b/static/js/tasks_browse.js
@@ -718,11 +718,13 @@ function prepareFilters() {
 }
 
 function refresh(dropFilters) {
-    var location = first_page_url + (!isNaN(records_per_page) ? ('/1/' + records_per_page) : '');
+    let location = (first_page_url || '') + (!isNaN(records_per_page) ? ('/1/' + records_per_page) : '');
+
     if (!dropFilters) {
-        var preparedFilters = prepareFilters();
+        const preparedFilters = prepareFilters();
         location += '?' + $.param(preparedFilters);
     }
+
     window.location.replace(location);
 }
 
@@ -731,9 +733,11 @@ window.addEventListener('clearFilters', function() {
 });
 
 function exportTasks(downloadType) {
-    var location = first_page_url + (!isNaN(records_per_page) ? ('/1/' + records_per_page) : '');
-    var preparedFilters = prepareFilters();
+    let location = (first_page_url || '') + (!isNaN(records_per_page) ? ('/1/' + records_per_page) : '');
+    const preparedFilters = prepareFilters();
+
     location += '?' + $.param(preparedFilters) + '&download_type=' + downloadType;
+
     window.location.replace(location);
 }
 

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -248,8 +248,8 @@
                 {% if 'gold_task' in filter_data.display_columns %}
                     {% if t.calibration %}
                         <td style="width: 100%">
-                            <!-- Allow project owners and admins to update Gold tasks -->
-                            {% if current_user.id in project.owners_ids or current_user.admin %}
+                            <!-- Allow project owner, sub-admin co-owners, and admins to update Gold tasks -->
+                            {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
                                 <a class="gold-task label label-warning" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) + '?mode=gold' }}">Update</a>
                             {% else %}
                                 <div class="gold-task label label-default" title="Only Project owners can update Gold tasks.">Update</div>
@@ -257,8 +257,8 @@
                         </td>
                     {% else %}
                     <td style="width: 100%">
-                        <!-- Allow project owners and admins to make Gold tasks -->
-                        {% if current_user.id in project.owners_ids or current_user.admin %}
+                        <!-- Allow project owner, sub-admin co-owners, and admins to make Gold tasks -->
+                        {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
                             <a class="gold-task label label-info" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) + '?mode=gold' }}">Make Gold</a>
                         {% else %}
                             <div class="gold-task label label-default" title="Only project owners can make Gold tasks.">Make Gold</div>

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -247,9 +247,23 @@
                 {% endif %}
                 {% if 'gold_task' in filter_data.display_columns %}
                     {% if t.calibration %}
-                    <td style="width: 100%"><a class="label label-warning" style="display: block; margin: 0 0.25rem" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) + '?mode=gold' }}">Update</a></td>
+                        <td style="width: 100%">
+                            <!-- Allow project owners and admins to update Gold tasks -->
+                            {% if current_user.id in project.owners_ids or current_user.admin %}
+                                <a class="gold-task label label-warning" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) + '?mode=gold' }}">Update</a>
+                            {% else %}
+                                <div class="gold-task label label-default" title="Only Project owners can update Gold tasks.">Update</div>
+                            {% endif %}
+                        </td>
                     {% else %}
-                    <td style="width: 100%"><a class="label label-info" style="display: block; margin: 0 0.25rem" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) + '?mode=gold' }}">Make Gold</a></td>
+                    <td style="width: 100%">
+                        <!-- Allow project owners and admins to make Gold tasks -->
+                        {% if current_user.id in project.owners_ids or current_user.admin %}
+                            <a class="gold-task label label-info" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) + '?mode=gold' }}">Make Gold</a>
+                        {% else %}
+                            <div class="gold-task label label-default" title="Only project owners can make Gold tasks.">Make Gold</div>
+                        {% endif %}
+                    </td>
                     {% endif %}
                 {% endif %}
                 {% if 'actions' in filter_data.display_columns %}


### PR DESCRIPTION
- Disabled the buttons **Make Gold** and **Update** for non-project owners and non-admins.
- Only project owners, sub-admin co-owners, and administrators may update a Gold task for a project.

## Project Owner Screenshot

This screenshot shows what the project owner sees when browsing tasks. The project owner (or an administrator) may create and/or update gold tasks.

![gold-project-owner](https://user-images.githubusercontent.com/529049/58490854-e49c1a80-813b-11e9-8c95-8be06dc61293.png)

## Non Sub-Admin Co-Owner Screenshot

This screenshot shows what a sub-administrator will see when browsing tasks. A sub-admin who is not the project owner may not make nor update gold tasks.

![gold-non-project-owner](https://user-images.githubusercontent.com/529049/58490855-e49c1a80-813b-11e9-9334-d837432a5f29.png)

*Note: To create a project, a user must be either an admin or sub-admin. The project owner and co-owners will be included in project.owners_ids. If a co-owner is not a sub-admin, they will only have read access to gold tasks.*

Referencing https://github.com/bloomberg/pybossa/pull/252