### PR TITLE
Validate correctly in component builder.

### DIFF
--- a/static/src/components/builder/components/PreviewCommons.vue
+++ b/static/src/components/builder/components/PreviewCommons.vue
@@ -86,13 +86,13 @@ export default {
           types[`GET_${this.$route.params.componentName}_FORM_VALID`];
         const isValidForm = getFormValidType
           ? this.$store.getters[getFormValidType]
-          : true;
+          : { isValid: true };
         return isValidForm;
       }
     },
     form: {
       get () {
-        let form = { isValidForm: true };
+        let form = { isValidForm: this.isValidForm };
         const getFormType =
           types[`GET_${this.$route.params.componentName}_PROPS`];
         if (getFormType) {


### PR DESCRIPTION
The component builder is not validating some of the components correctly which is preventing the code generation and preview for them. This is due to a change we made to validation to return an object instead of a boolean, and we forgot to update some of the component builders.