### PR TITLE
RDISCROWD-1694 Style fix for css word-break

### DIFF
--- a/templates/projects/task_presenter_editor.html
+++ b/templates/projects/task_presenter_editor.html
@@ -42,6 +42,8 @@
     #sync-panels table {
       margin-top: 6px;
       margin-bottom: 0;
+    }
+    #sync-panels table td.ref-details {
       word-break: break-word;
     }
     #sync-panels .message {
@@ -136,7 +138,7 @@
                                 </tr>
                                 <tr>
                                     <td><p>Last Commit:</p></td>
-                                    <td><a href={{ project.info.ref_url }} target="_blank">{{ project.info.ref }}</a></td>
+                                    <td class="ref-details"><a href={{ project.info.ref_url }} target="_blank">{{ project.info.ref }}</a></td>
                                 </tr>
                               </table>
                           {% else %}
@@ -166,14 +168,14 @@
                                   </tr>
                                   <tr>
                                       <td><p>Synced With:</p></td>
-                                      <td><a href={{ project.info.sync.source_url + '/project/' + project.short_name }} target="_blank">
+                                      <td class="ref-details"><a href={{ project.info.sync.source_url + '/project/' + project.short_name }} target="_blank">
                                               {{ project.info.sync.source_url + '/project/' + project.short_name }}
                                       </a></td>
                                   </tr>
                                   {% if project.info.sync.ref and project.info.sync.ref_url %}
                                   <tr>
                                       <td><p>GitHub Reference:</p></td>
-                                      <td><a href={{ project.info.sync.ref_url }} target="_blank">
+                                      <td class="ref-details"><a href={{ project.info.sync.ref_url }} target="_blank">
                                               {{ project.info.sync.ref }}
                                       </a></td>
                                   </tr>

--- a/templates/projects/task_presenter_editor.html
+++ b/templates/projects/task_presenter_editor.html
@@ -42,6 +42,7 @@
     #sync-panels table {
       margin-top: 6px;
       margin-bottom: 0;
+      word-break: break-word;
     }
     #sync-panels .message {
       margin-top: 10px;


### PR DESCRIPTION
- Fix for word-break.

## Before

![word-break-1](https://user-images.githubusercontent.com/529049/59771753-603f4200-9278-11e9-9578-9bfd50340ea9.PNG)

## After

![word-break-2](https://user-images.githubusercontent.com/529049/59771754-603f4200-9278-11e9-850a-b12a4b0f2bf7.PNG)
