### PR TITLE
Add dropdown for tag name.

### DIFF
--- a/static/src/components/builder/components/CheckboxInput/CheckboxInputForm.vue
+++ b/static/src/components/builder/components/CheckboxInput/CheckboxInputForm.vue
@@ -56,7 +56,7 @@
             <label
               class="block-label"
             >
-              Answer field name
+              Answer field name | <span class="label-tip">The field where the worker's answer is stored. Can be JSON path like a.b.c.</span>
               <input
                 id="pyb-answer"
                 :value="checkbox['pyb-answer']"
@@ -104,6 +104,11 @@
   font-size: 16px;
   font-weight: 400;
   display: block;
+}
+.label-tip {
+  font-style: italic;
+  font-weight: 400;
+  font-size: smaller;
 }
 .scroll {
   overflow-x: hidden;

--- a/static/src/components/builder/components/RadioInput/RadioInputForm.vue
+++ b/static/src/components/builder/components/RadioInput/RadioInputForm.vue
@@ -23,7 +23,7 @@
         class="col-labels"
         for="pyb-answer"
       >
-        Answer field name | <span class="label-tip">The field where the worker's answer is stored.</span>
+        Answer field name | <span class="label-tip">The field where the worker's answer is stored. Can be JSON path like a.b.c.</span>
       </label>
       <input
         id="pyb-answer"

--- a/static/src/components/builder/components/Table/TableForm.vue
+++ b/static/src/components/builder/components/Table/TableForm.vue
@@ -94,8 +94,8 @@
               v-if="columnWithComponent"
               class="form-group"
             >
-              <label for="add-label">
-                * Table Answer field Name | <span class="label-tip">The field where the worker's answers for the table are stored.</span>
+              <label for="table-answer-name">
+                * Table Answer field Name | <span class="label-tip">The field where the worker's answers for the table are stored. Can be JSON path like a.b.c.</span>
               </label>
               <input
                 id="table-answer-name"
@@ -143,6 +143,7 @@
             </div>
             <label
               v-if="data.isVariable"
+              for="data-source-name"
               class="col-form-label-md pull-left"
             >
               * Field Data Source Name | <span class="label-tip">The variable in your code that contains the table data. For example, task.info.tableData.</span>

--- a/static/src/components/builder/components/TextInput/TextInputForm.vue
+++ b/static/src/components/builder/components/TextInput/TextInputForm.vue
@@ -32,7 +32,7 @@
                 for="pyb-answer"
                 class="col-form-label-sm"
               >
-                Answer field name
+                Answer field name | <span class="label-tip">The field where the worker's answer is stored. Can be JSON path like a.b.c.</span>
               </label>
               <input
                 id="pyb-answer"
@@ -48,7 +48,13 @@
     </div>
   </div>
 </template>
-
+<style scoped>
+.label-tip {
+  font-style: italic;
+  font-weight: 400;
+  font-size: smaller;
+}
+</style>
 <script>
 import * as types from '../../store/types';
 import { mapMutations, mapState } from 'vuex';

--- a/static/src/components/builder/components/TextTagging/TextTaggingForm.vue
+++ b/static/src/components/builder/components/TextTagging/TextTaggingForm.vue
@@ -42,6 +42,7 @@
       <select
         id="editMode"
         v-model="editMode"
+        class="form-control"
         :class="{'danger-validation':getErrors(`readOnly`)}"
       >
         <option
@@ -85,12 +86,15 @@
           class="block-label"
         >
           Name | <span class="label-tip">The tag name to store in the answer.</span>
-          <input
+          <select
             v-model="tag.name"
             class="form-control form-control-sm"
             :class="{'danger-validation':getErrors(`tagList[${index}].name`)}"
-            type="text"
           >
+            <option>ORG</option>
+            <option>PER</option>
+            <option>CUR</option>
+          </select>
         </label>
         <div class="danger-validation-text">
           {{ getErrors(`tagList[${index}].name`) }}
@@ -131,7 +135,7 @@
       class="btn btn-default btn-sm col-sm-2"
       @click="addTag"
     >
-      Add Tag
+      New Tag
     </button>
     <br>
     <div>
@@ -328,9 +332,6 @@
   font-style: italic;
   font-weight: 400;
   font-size: smaller;
-}
-.label-tip:hover {
-  font-size: larger
 }
 .scroll {
   overflow-x: hidden;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1828*

**Describe your changes**
Made NLP Enrichment component builder tag name field into a dropdown instead of text box.
Added standard label tip for "Answer field name" on all component builders.
Corrected dropdown appearance.
Fixed some label->control associations. 
Removed zoom on hover for label tip.
Changed wording from "Add Tag" to "New Tag" on add tag button.

**Testing performed**
Manual