### PR TITLE
Update RadioInput builder for v0.3.4.

### DIFF
--- a/static/src/components/builder/components/RadioInput/RadioCreator.vue
+++ b/static/src/components/builder/components/RadioInput/RadioCreator.vue
@@ -11,7 +11,7 @@
             :id="radio.id"
             :value="radio.value"
             :pyb-answer="pybAnswer"
-            :initial-value="!!initialValue && (initialValue == radio.value)"
+            :initial-value="initialValue"
             :name="name"
           />
           {{ radio.label }}

--- a/static/src/components/builder/components/RadioInput/radioInputTemplate.html
+++ b/static/src/components/builder/components/RadioInput/radioInputTemplate.html
@@ -1,5 +1,5 @@
 <div class="radio">
     <label>
-        <radio-input value="{{value}}" :initial-value="{{initialValue}}" pyb-answer="{{pybAnswer}}" name="{{name}}"></radio-input> {{label}}
+        <radio-input value="{{value}}" initial-value="{{initialValue}}" pyb-answer="{{pybAnswer}}" name="{{name}}"></radio-input> {{label}}
     </label>
 </div>

--- a/static/src/components/builder/utils.js
+++ b/static/src/components/builder/utils.js
@@ -172,7 +172,7 @@ export default {
         ...this.getValuesForTemplate(radio),
         pybAnswer,
         name,
-        initialValue: !!initialValue && (radio.value === initialValue)
+        initialValue
       };
       let radioOutput = Mustache.render(
         radioInputTemplate,

--- a/static/src/package.json
+++ b/static/src/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@dtwebservices/task-presenter-components": "0.3.2",
+    "@dtwebservices/task-presenter-components": "0.3.4",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/test-utils": "^1.0.0-beta.28",
     "axios": "^0.16.2",

--- a/static/src/test/utils.spec.js
+++ b/static/src/test/utils.spec.js
@@ -87,8 +87,7 @@ it('getRadioGroupCode for RADIO_INPUT', () => {
   expect(componentCode.includes(
     `pyb-answer="${radioInput.pybAnswer}"`)).toBeTruthy();
   expect(componentCode.includes(radioInput.radioList[1].label)).toBeTruthy();
-  expect(componentCode.includes(`:initial-value="true"`)).toBeTruthy();
-  expect(componentCode.includes(`:initial-value="false"`)).toBeTruthy();
+  expect(componentCode.includes(`initial-value="A"`)).toBeTruthy();
   expect(componentCode.includes(`value="${radioInput.radioList[0].value}"`)).toBeTruthy();
   expect(componentCode.includes(`value="${radioInput.radioList[1].value}"`)).toBeTruthy();
   expect(componentCode.includes(`name="${radioInput.name}"`)).toBeTruthy();


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1868*

**Describe your changes**
We changed the way initial values are specified for RadioInput components. So we have to update the component builder to use the new way.

**Testing performed**
Manual

