### PR TITLE
Fix invalid generated NLP Enrichment component.

### DIFF
--- a/static/src/components/builder/components/TextTagging/TextTaggingForm.vue
+++ b/static/src/components/builder/components/TextTagging/TextTaggingForm.vue
@@ -135,7 +135,7 @@
       class="btn btn-default btn-sm col-sm-2"
       @click="addTag"
     >
-      New Tag
+      Add Another Tag
     </button>
     <br>
     <div>
@@ -311,7 +311,7 @@
         class="btn btn-default btn-sm col-sm-2 col-md-2"
         @click="addEntity"
       >
-        Add Entity
+        Add {{ entityList.length ? 'Another ' : '' }}Entity
       </button>
     </template>
   </div>

--- a/static/src/components/builder/store/modules/textTagging.js
+++ b/static/src/components/builder/store/modules/textTagging.js
@@ -73,7 +73,7 @@ function getEntities (state) {
     case 'variable':
       const preview = state.useStaticInPreview ? getStaticEntities() : [];
       return {
-        snippet: state.entities.variable,
+        snippet: state.entities.variable.trim() || [],
         preview
       };
     case 'static':


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1877*

**Describe your changes**
When the entities variable binding is not specified in the NLP Enrichment component builder, the generated code is invalid.

**Testing performed**
Manual
