### PR TITLE
Show quiz enabled state in quiz table.

### DIFF
--- a/templates/projects/quiz_mode.html
+++ b/templates/projects/quiz_mode.html
@@ -9,6 +9,7 @@
     <thead>
         <tr>
             <th>User</th>
+            <th>Enabled</th>
             <th>Status</th>
             <th>Right</th>
             <th>Wrong</th>
@@ -20,6 +21,7 @@
 {% for user in all_user_quizzes %}
         <tr>
             <td>{{user.fullname}}</td>
+            <td>{{'Yes' if user.quiz.config.enabled else 'No'}}</td>
             <td class="{{ {'passed':'bg-success','failed':'bg-danger'}.get(user.quiz.status, '') }}">{{user.quiz.status}}</td>
             <td>{{user.quiz.result.right}}</td>
             <td>{{user.quiz.result.wrong}}</td>


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1892*

**Describe your changes**
In the quiz result table we need to show whether the quiz is enabled for a user. Not showing this information can lead to a project owner not being able to diagnose why a user is not entering quiz mode.

**Testing performed**
Manual
