### PR TITLE
Hide gold task info for worker co-owners.

### DIFF
--- a/templates/projects/tasks_browse.html
+++ b/templates/projects/tasks_browse.html
@@ -19,13 +19,19 @@
         <p>{{_('For each task, you can find the following information')}}:
         <ul>
             <li><strong>{{_('Task')}} </strong><span class="label label-info">#0000</span> {{_('This number identifies the task for the project and it is unique')}}</li>
+            {% if can_know_task_is_gold %}
             <li><strong>0 of 30</strong>: {{_('The first number shows how many answers have been submitted for the task and the')}} {{_('second number')}} {{_('how many need to be obtained to mark the task as')}} <strong>{{_('completed')}}</strong>.
             {{_(' As gold tasks has no redundancy, this would be blank for gold tasks')}}.</li>
+            {% endif %}
             <li><strong>{{_('Priority')}}</strong>: {{_('Shows the priority of the task, priority ranges from 0.0 (lowest value) to 1.0 (highest priority)')}}.</li>
+            {% if can_know_task_is_gold %}
             <li><strong>%{{_('Complete')}}</strong>: {{_('Shows the percentage that has been completed of the task')}}.{{_(' This would be blank for gold tasks as such tasks has no redundancy and would never complete')}}.</li>
+            {% endif %}
             <li><strong>{{_('Created')}}</strong>: {{_('When the task was created')}}.</li>
             <li><strong>{{_('Completed')}}</strong>: {{_('When the task became fully completed')}}.</li>
+            {% if can_know_task_is_gold %}
             <li><strong>{{_('Gold Tasks')}}</strong>: {{_('Shows whether task is gold task(Y) or not(N)')}}.</li>
+            {% endif %}
             <li><strong>{{_('Actions')}}</strong>: {{_('Download or view task results')}}.</li>
         </ul>
         </p>
@@ -67,10 +73,14 @@
             <ul class="dropdown-menu" aria-labelledby="btnColumnsSettings">
                 <li><a href="#" class="columns_settings" data-value="task_id" tabIndex="-1"><input type="checkbox" {{ "checked" if "task_id" in filter_data.display_columns }} disabled="disabled" />&nbsp;Task Id</a></li>
                 <li><a href="#" class="columns_settings" data-value="priority" tabIndex="-1"><input type="checkbox" {{ "checked" if "priority" in filter_data.display_columns }}/>&nbsp;Priority</a></li>
+                {% if can_know_task_is_gold %}
                 <li><a href="#" class="columns_settings" data-value="pcomplete" tabIndex="-1"><input type="checkbox" {{ "checked" if "pcomplete" in filter_data.display_columns }}/>&nbsp;%Complete</a></li>
+                {% endif %}
                 <li><a href="#" class="columns_settings" data-value="created" tabIndex="-1"><input type="checkbox" {{ "checked" if "created" in filter_data.display_columns }}/>&nbsp;Created</a></li>
                 <li><a href="#" class="columns_settings" data-value="finish_time" tabIndex="-1"><input type="checkbox" {{ "checked" if "finish_time" in filter_data.display_columns }}/>&nbsp;Completed</a></li>
+                {% if can_know_task_is_gold %}
                 <li><a href="#" class="columns_settings" data-value="gold_task" tabIndex="-1"><input type="checkbox" {{ "checked" if "gold_task" in filter_data.display_columns }}/>&nbsp;Gold Task</a></li>
+                {% endif %}
                 <li><a href="#" class="columns_settings" data-value="actions" tabIndex="-1"><input type="checkbox" {{ "checked" if "actions" in filter_data.display_columns }}/>&nbsp;Actions</a></li>
             </ul>
         </li>
@@ -217,11 +227,13 @@
                     {% else %}
                         <a class="label label-info" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id) }}">#{{ t.id }}</a>
                     {% endif %}
-                    {{ t.n_task_runs|int }} {{_('of')}}
-                    {% if t.calibration %}
-                      &infin;
-                    {% else %}
-                      {{ t.n_answers }}
+                    {% if can_know_task_is_gold %}
+                      {{ t.n_task_runs|int }} {{_('of')}}
+                      {% if t.calibration %}
+                        &infin;
+                      {% else %}
+                        {{ t.n_answers }}
+                      {% endif %}
                     {% endif %}
                 </td>
                 {% endif %}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-1476*

**Describe your changes**
We do not want worker co-owners to be able to tell which tasks are gold tasks. So in the task browse screen we need to hide any information that would give that away. Hiding the task redundancy, % complete, and Gold columns does that, along with removing gold_answers from results.json.

We probably still need to modify the downloaded reports to hide the gold info.

**Testing performed**
Manual testing with a worker co-owner account I created.
