### PR TITLE
RDISCROWD-1867 Github and Sync Panel Collapse and Styling

### DIFF
--- a/templates/projects/task_presenter_editor.html
+++ b/templates/projects/task_presenter_editor.html
@@ -148,82 +148,80 @@
               </div>
 
               <div id="sync-panels" class="row">
-                      <div class="col-md-6">
-                        <div class="panel panel-info">
-                          <div class="panel-heading">
-                            <a class="accordion-panel" role="button" data-toggle="collapse" data-parent="#sync-panels" href="#panel-github" aria-expanded="true" aria-controls="panel-github">
-                              Latest GitHub Push Details
-                            </a>
-                          </div>
-                          <div id="panel-github" class="panel-body collapse in">
-                            {% if project.info.pusher and project.info.timestamp and project.info.ref_url and project.info.ref%}
-                                <table class="table table-hover table-condensed" >
-                                  <tr>
-                                      <td ><p>Author:</p></td>
-                                      <td><p>{{ project.info.pusher }}</p></td>
-                                  </tr>
-                                  <tr>
-                                      <td><p>Message:</p></td>
-                                      <td><p>{{ project.info.message }}</p></td>
-                                  </tr>
-                                  <tr>
-                                      <td><p>Last Updated:</p></td>
-                                      <td><p>{{ project.info.timestamp }}</p></td>
-                                  </tr>
-                                  <tr>
-                                      <td><p>Last Commit:</p></td>
-                                      <td class="ref-details"><a href={{ project.info.ref_url }} target="_blank">{{ project.info.ref }}</a></td>
-                                  </tr>
-                                </table>
-                            {% else %}
-                                <p class="message">Task presenter code was not updated via GitHub</p>
-                            {% endif %}
-                          </div>
-                        </div>
-                      </div>
-                      <div class="col-md-6">
-                        <div class="panel panel-info">
-                          <div class="panel-heading">
-                            <a class="accordion-panel" role="button" data-toggle="collapse" data-parent="#sync-panels" href="#panel-sync" aria-expanded="true" aria-controls="panel-sync">
-                              Latest Project Sync Details
-                            </a>
-                          </div>
-                          <div id="panel-sync" class="panel-body collapse in">
-                            {% if project.info.sync %}
-                              {% if project.info.sync.syncer and project.info.sync.latest_sync and project.info.sync.source_url %}
-                                  <table class="table table-hover table-condensed">
-                                    <tr>
-                                        <td><p>Syncer:</p></td>
-                                        <td><p>{{ project.info.sync.syncer }}</p></td>
-                                    </tr>
-                                    <tr>
-                                        <td><p>Last Synced:</p></td>
-                                        <td><p>{{ project.info.sync.latest_sync }}</p></td>
-                                    </tr>
-                                    <tr>
-                                        <td><p>Synced With:</p></td>
-                                        <td class="ref-details"><a href={{ project.info.sync.source_url + '/project/' + project.short_name }} target="_blank">
-                                                {{ project.info.sync.source_url + '/project/' + project.short_name }}
-                                        </a></td>
-                                    </tr>
-                                    {% if project.info.sync.ref and project.info.sync.ref_url %}
-                                    <tr>
-                                        <td><p>GitHub Reference:</p></td>
-                                        <td class="ref-details"><a href={{ project.info.sync.ref_url }} target="_blank">
-                                                {{ project.info.sync.ref }}
-                                        </a></td>
-                                    </tr>
-                                    {% endif %}
-                                  </table>
-                              {% else %}
-                                  <p class="message">Task presenter code was not updated via project syncing</p>
-                              {% endif %}
-                            {% else %}
-                              <p class="message">Task presenter code was not updated via project syncing</p>
-                            {% endif %}
-                          </div>
-                        </div>
-                      </div>
+                <div class="col-md-6">
+                  <div class="panel panel-info">
+                    {% set github_data_exists = project.info.pusher and project.info.timestamp and project.info.ref_url and project.info.ref %}
+                    <div class="panel-heading">
+                      <a class="accordion-panel {{ 'collapsed' if not github_data_exists else '' }}" role="button" data-toggle="collapse" data-parent="#sync-panels" href="#panel-github" aria-expanded="true" aria-controls="panel-github">
+                        Latest GitHub Push Details
+                      </a>
+                    </div>
+                    <div id="panel-github" class="panel-body collapse {{ 'in' if github_data_exists else '' }}">
+                      {% if github_data_exists %}
+                          <table class="table table-hover table-condensed" >
+                            <tr>
+                                <td ><p>Author:</p></td>
+                                <td><p>{{ project.info.pusher }}</p></td>
+                            </tr>
+                            <tr>
+                                <td><p>Message:</p></td>
+                                <td><p>{{ project.info.message }}</p></td>
+                            </tr>
+                            <tr>
+                                <td><p>Last Updated:</p></td>
+                                <td><p>{{ project.info.timestamp }}</p></td>
+                            </tr>
+                            <tr>
+                                <td><p>Last Commit:</p></td>
+                                <td class="ref-details"><a href={{ project.info.ref_url }} target="_blank">{{ project.info.ref }}</a></td>
+                            </tr>
+                          </table>
+                      {% else %}
+                          <p class="message">Task presenter code was not updated via GitHub</p>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="panel panel-info">
+                    {% set sync_data_exists = project.info.sync and project.info.sync.syncer and project.info.sync.latest_sync and project.info.sync.source_url %}
+                    <div class="panel-heading">
+                      <a class="accordion-panel {{ 'collapsed' if not sync_data_exists else '' }}" role="button" data-toggle="collapse" data-parent="#sync-panels" href="#panel-sync" aria-expanded="true" aria-controls="panel-sync">
+                        Latest Project Sync Details
+                      </a>
+                    </div>
+                    <div id="panel-sync" class="panel-body collapse {{ 'in' if sync_data_exists else '' }}">
+                      {% if sync_data_exists %}
+                        <table class="table table-hover table-condensed">
+                          <tr>
+                              <td><p>Syncer:</p></td>
+                              <td><p>{{ project.info.sync.syncer }}</p></td>
+                          </tr>
+                          <tr>
+                              <td><p>Last Synced:</p></td>
+                              <td><p>{{ project.info.sync.latest_sync }}</p></td>
+                          </tr>
+                          <tr>
+                              <td><p>Synced With:</p></td>
+                              <td class="ref-details"><a href={{ project.info.sync.source_url + '/project/' + project.short_name }} target="_blank">
+                                      {{ project.info.sync.source_url + '/project/' + project.short_name }}
+                              </a></td>
+                          </tr>
+                          {% if project.info.sync.ref and project.info.sync.ref_url %}
+                          <tr>
+                              <td><p>GitHub Reference:</p></td>
+                              <td class="ref-details"><a href={{ project.info.sync.ref_url }} target="_blank">
+                                      {{ project.info.sync.ref }}
+                              </a></td>
+                          </tr>
+                          {% endif %}
+                        </table>
+                      {% else %}
+                        <p class="message">Task presenter code was not updated via project syncing</p>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
               </div>
 
               <div id="modal-preview" class="modal fade" tabindex="-1" role="dialog">

--- a/templates/projects/task_presenter_editor.html
+++ b/templates/projects/task_presenter_editor.html
@@ -153,7 +153,8 @@
                     {% set github_data_exists = project.info.pusher and project.info.timestamp and project.info.ref_url and project.info.ref %}
                     <div class="panel-heading">
                       <a class="accordion-panel {{ 'collapsed' if not github_data_exists else '' }}" role="button" data-toggle="collapse" data-parent="#sync-panels" href="#panel-github" aria-expanded="true" aria-controls="panel-github">
-                        Latest GitHub Push Details
+                        <i class="fa fa-github-square" style='margin-right: 5px;'></i>
+                        <span>Latest GitHub Push Details</span>
                       </a>
                     </div>
                     <div id="panel-github" class="panel-body collapse {{ 'in' if github_data_exists else '' }}">
@@ -177,7 +178,7 @@
                             </tr>
                           </table>
                       {% else %}
-                          <p class="message">Task presenter code was not updated via GitHub</p>
+                          <p class="message">Task presenter code was not updated via GitHub.</p>
                       {% endif %}
                     </div>
                   </div>
@@ -187,7 +188,8 @@
                     {% set sync_data_exists = project.info.sync and project.info.sync.syncer and project.info.sync.latest_sync and project.info.sync.source_url %}
                     <div class="panel-heading">
                       <a class="accordion-panel {{ 'collapsed' if not sync_data_exists else '' }}" role="button" data-toggle="collapse" data-parent="#sync-panels" href="#panel-sync" aria-expanded="true" aria-controls="panel-sync">
-                        Latest Project Sync Details
+                        <i class="fa fa-retweet" style='margin-right: 5px;'></i>
+                        <span>Latest Project Sync Details</span>
                       </a>
                     </div>
                     <div id="panel-sync" class="panel-body collapse {{ 'in' if sync_data_exists else '' }}">
@@ -217,7 +219,7 @@
                           {% endif %}
                         </table>
                       {% else %}
-                        <p class="message">Task presenter code was not updated via project syncing</p>
+                        <p class="message">Task presenter code was not updated via project syncing.</p>
                       {% endif %}
                     </div>
                   </div>


### PR DESCRIPTION
- Collapse github and sync panels by default if no information is present.
- Added icon styling to panels.

## Screenshots

### Panels collapsed by default

![panels-collapsed](https://user-images.githubusercontent.com/50708624/62376788-772bb200-b50f-11e9-876e-b344b1659643.png)

### Expanded panels and new icon stle

![panels-expanded](https://user-images.githubusercontent.com/50708624/62376789-772bb200-b50f-11e9-9530-cc97fb507b78.png)
