### PR TITLE
Fix guidelines display

### DIFF
--- a/templates/projects/presenter.html
+++ b/templates/projects/presenter.html
@@ -52,7 +52,7 @@
     <link rel="stylesheet" type="text/css" href="{{ ASSET_URL }}">
 {% endassets %}
 <script type="text/javascript">
-    $("#annotations-guidelines-content").append('{{project.info.task_guidelines|safe}}')
+    $("#annotations-guidelines-content").append({{project.info.task_guidelines|tojson}})
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Fix guidelines display when it has special characters like '

