### PR TITLE
add opt-in annotation option. refactor annotation config in separate …

### DIFF
--- a/templates/account/profile.html
+++ b/templates/account/profile.html
@@ -28,7 +28,7 @@
     </div>
 </section>
 
-<script src="/static/js/gen/userprofile.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/userprofile.min.9fed6a985f3b0b4d3da2.js"></script>
 {% endblock %}
 
 

--- a/templates/admin/new_announcement.html
+++ b/templates/admin/new_announcement.html
@@ -11,6 +11,6 @@
     <Announcementimagecrop :level-options="{{levelOptions}}"/>
 </div>
 
-<script src="/static/js/gen/editor.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/editor.min.9fed6a985f3b0b4d3da2.js"></script>
 
 {% endblock %}

--- a/templates/projects/annotations.html
+++ b/templates/projects/annotations.html
@@ -1,0 +1,26 @@
+{% extends "projects/base.html" %}
+{% set active_page = "projects" %}
+{% set active_link  = "settings" %}
+{% set section = _('Configure Annotation Parameters') %}
+
+{% import "projects/_helpers.html" as helper %}
+{% from "_formhelpers.html" import render_field, render_checkbox_field, render_select2_field %}
+
+{% block projectcontent %}
+<form method="post" action="{{ url_for('project.annotation_config', short_name=project.short_name) }}">
+    <fieldset>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {{ render_field(form.dataset_description, class_="input-xlarge", placeholder=_('Describe type of data that will be annotated. (e.g., The data annotated in this project are Chinese BN news articles.)')) }}
+        {{ render_field(form.provider) }}
+        {{ render_field(form.restrictions_and_permissioning, class_="input-xlarge", placeholder=_('A complete list of relevant security-related properties and requirements of the dataset (e.g., Original data is stored in <storage>, under <role>, and encrypted)')) }}
+        {{ render_field(form.sampling_method, placeholder=_('Sampling method of data selection')) }}
+        {{ render_field(form.sampling_script, placeholder=_('Pointer to example script or github repo that shows how data was selected/sampled (link)')) }}
+        {{ render_field(form.label_aggregation_strategy, placeholder=_('Label aggregation strategy that should be used')) }}
+        {{ render_field(form.task_input_schema, placeholder=_('The schema that serves task presenter input data (e.g., task request field schema)')) }}
+        {{ render_field(form.task_output_schema, placeholder=_('The schema produced by task presenter that serves as task output data (e.g., task response field schema)')) }}
+        <div class="form-actions">
+            <button type="submit" name='btn' value="Save the changes" class="btn btn-primary">{{_('Save the changes')}}</button>
+        </div>        
+    </fieldset>
+</form>
+{% endblock %}

--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<script src="/static/js/gen/answerfieldsconfig.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/answerfieldsconfig.min.9fed6a985f3b0b4d3da2.js"></script>
 
 <script>
 answerFields.setData({

--- a/templates/projects/component_helper.html
+++ b/templates/projects/component_helper.html
@@ -3,6 +3,6 @@
 <div id="component-helper" class = "col-md-6">
     <builder></builder>
 </div>
-<script src="/static/js/gen/component_helper.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/component_helper.min.9fed6a985f3b0b4d3da2.js"></script>
 
 {% endblock %}

--- a/templates/projects/new.html
+++ b/templates/projects/new.html
@@ -4,7 +4,7 @@
 {% import "account/_helpers.html" as helper %}
 
 {% block content %}
-{% from "_formhelpers.html" import render_field, render_select2_field%}
+{% from "_formhelpers.html" import render_field, render_select2_field, render_checkbox_field%}
 
 <section class="account profile">
 <div id="app-form" class="container">
@@ -33,6 +33,10 @@
             {{ render_field(form.kpi) }}
             {% if 'data_access' in form %}
                 {{ render_select2_field(form.data_access) }}
+            {% endif %}
+            {% if 'amp_store' in form %}
+                {{ render_checkbox_field(form.amp_store, tooltip=_('Opt in to store annotations on Annotation Management Platform')) }}
+                {{ render_field(form.amp_pvf, placeholder=_('PVF that should be used for annotation store')) }}
             {% endif %}
             <div class="form-actions">
                 <input type="submit" value={{_('Create the project')}} class="btn btn-primary" />

--- a/templates/projects/new_blogpost.html
+++ b/templates/projects/new_blogpost.html
@@ -9,6 +9,6 @@
 <div id="editorpybossa">
     <Imagecrop/>
 </div>
-<script src="/static/js/gen/editor.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/editor.min.9fed6a985f3b0b4d3da2.js"></script>
 
 {% endblock %}

--- a/templates/projects/performancestats.html
+++ b/templates/projects/performancestats.html
@@ -14,6 +14,6 @@
     </performance-stats>
 </div>
 
-<script src="/static/js/gen/performancestats.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/performancestats.min.9fed6a985f3b0b4d3da2.js"></script>
 {{ helper.broken_image() }}
 {% endblock %}

--- a/templates/projects/settings.html
+++ b/templates/projects/settings.html
@@ -41,13 +41,16 @@
     </div>
 </div>
 
-{% if private_instance %}
 <div class="row">
+    {% if private_instance %}
     <div id="assign_users_to_project" class="col-md-6">
         {{ render_project_card_option(project, upload_method, title=_('Assign Users To Project'), explanation=_('Assign users to project based on matching data access levels'), link=url_for('project.assign_users', short_name=project.short_name), link_action_text=_('Assign Users'), icon='users')}}
     </div>
+    {% endif %}
+    <div id="annotation_config" class="col-md-6">
+        {{ render_project_card_option(project, upload_method, title=_('Annotation Configuration'), explanation=_('Configure parameters related to annotation'), link=url_for('project.annotation_config', short_name=project.short_name), link_action_text=_('Annotation'), icon='cogs')}}
+    </div>
 </div>
-{% endif %}
 
 {% endif %}
 

--- a/templates/projects/summary.html
+++ b/templates/projects/summary.html
@@ -54,7 +54,7 @@
     </div>
 </div>
 
-<script src="/static/js/gen/setting.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/setting.min.9fed6a985f3b0b4d3da2.js"></script>
 
 {% endblock %}
 

--- a/templates/projects/tasks_browse.html
+++ b/templates/projects/tasks_browse.html
@@ -589,7 +589,7 @@
 </div>
 </div>
 
-<script src="/static/js/gen/task_browse.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/task_browse.min.9fed6a985f3b0b4d3da2.js"></script>
 <script type="text/javascript">
     var filter_data = {{ filter_data|tojson }};
     taskBrowse.setFilters(filter_data);

--- a/templates/projects/update.html
+++ b/templates/projects/update.html
@@ -31,18 +31,13 @@
         {{ render_field(form.name, class_="input-xlarge", placeholder=_('The name of the project')) }}
         {{ render_field(form.description, class_="input-xlarge", placeholder=_('Give some details about the project')) }}
         {{ render_field(form.long_description, class_="input-xlarge", placeholder=_('Explain the project (use Markdown!)')) }}
-        {{ render_field(form.dataset_description, class_="input-xlarge", placeholder=_('A short description of the type of data(set) that will be annotated along with representative examples. (e.g., The data annotated in this project are Chinese BN news articles.)')) }}
-        {{ render_field(form.provider) }}
-        {{ render_field(form.restrictions_and_permissioning, class_="input-xlarge", placeholder=_('A complete list of relevant security-related properties and requirements of the dataset (e.g., Original data is stored in the Data DMZ, behind PVF, and encrypted)')) }}
-        {{ render_field(form.store_pvf, placeholder=_('PVF that should be used for annotation store')) }}
-        {{ render_field(form.sampling_method, placeholder=_('Sampling method of data selection')) }}
-        {{ render_field(form.sampling_script, placeholder=_('Pointer to example script or github repo that shows how data was selected/sampled (link)')) }}
-        {{ render_field(form.label_aggregation_strategy, placeholder=_('Label aggregation strategy that should be used')) }}
-        {{ render_field(form.task_input_schema, placeholder=_('The schema of the data that is sent to GIGwork and that serves as task presenter input data (i.e., schema of data in task request field)')) }}
-        {{ render_field(form.task_output_schema, placeholder=_('The schema of the data that is produced by the GIGwork task presenter and that serves as task output data (i.e., schema of data in task response field)')) }}
         {{ render_field(form.product) }}
         {{ render_field(form.subproduct) }}
         {{ render_field(form.kpi) }}
+        {% if 'amp_store' in form %}
+            {{ render_checkbox_field(form.amp_store, tooltip=_('Opt in to store annotations on Annotation Management Platform')) }}
+            {{ render_field(form.amp_pvf, placeholder=_('PVF that should be used for annotation store')) }}
+        {% endif %}
         {{ render_field(form.category_id) }}
         {{ render_checkbox_field(form.allow_anonymous_contributors, tooltip=_('Check if you want to allow anonymous users contribute to your project')) }}
         {{ render_checkbox_field(form.hidden, tooltip=_('Check if you want to hide your project'))}}

--- a/templates/projects/wizard.html
+++ b/templates/projects/wizard.html
@@ -3,6 +3,6 @@
 <div id="wizard" class = "col-md-12">
 <wizard :steps="{{get_wizard_steps(project)}}" ></wizard>
 </div>
-<script src="/static/js/gen/wizard.min.14babfc9bf5df48d84f5.js"></script>
+<script src="/static/js/gen/wizard.min.9fed6a985f3b0b4d3da2.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
**Describe your changes**
Add option for opt-in to store annotations on amp. Opt-in and pvf to be accessible and cleary visible, hence are part of project settings. Rest of annotation configs are optional and are refactored to be part of a  new form that can be loaded from a new tile - annotation configs under proj settings 

**Testing performed**
create/update form w/ and w/o annotation configs. test through project details and api that updated configs are available.
