### PR TITLE
Fixed issues with duplicated ids

### DIFF
--- a/templates/projects/settings.html
+++ b/templates/projects/settings.html
@@ -15,10 +15,10 @@
 
 {% if current_user.admin or current_user.id in project.owners_ids %}
 <div class="row">
-    <div id="import_tasks" class="col-md-6">
+    <div id="delete_project" class="col-md-6">
         {{ render_project_card_option(project, upload_method, title=_('Delete Project'), explanation=_('Delete the project, tasks, task runs and answers.'), link=url_for('project.delete', short_name=project.short_name), link_action_text=_('Delete'), icon='trash')}}
     </div>
-    <div id="export_tasks" class="col-md-6">
+    <div id="data_enrichment" class="col-md-6">
         {{ render_project_card_option(project, upload_method, title=_('Data Enrichment'), explanation=_('Configure project for task data to be enriched.'), link=url_for('project.configure_enrichment', short_name=project.short_name), link_action_text=_('Enrich'), icon='pencil')}}
     </div>
 </div>

--- a/templates/projects/update.html
+++ b/templates/projects/update.html
@@ -51,7 +51,7 @@
             <h3>{{_('Enable project syncing')}}</h3>
             {{ render_checkbox_field(form.sync_enabled, class_="", tooltip=_('Check if you want to enable project syncing')) }}
         {% endif %}
-        <div id='password'>{{ render_field(form.password, placeholder="Leave blank to maintain set password") }}</div>
+        {{ render_field(form.password, placeholder="Leave blank to maintain set password") }}
         {% if 'data_access' in form %}
             {{ render_select2_field(form.data_access) }}
         {% endif %}


### PR DESCRIPTION
Two options `delete project` and `data enrichment` had mismatching ids which conflicted with other ids on the page.
The password field had both a div and an input with the same id, so I removed the div.
```
<div id="password"><div class="form-group ">
<label for="password" class="control-label"><label for="password">Password</label></label>
<input class="form-control" id="password" name="password" placeholder="Leave blank to maintain set password" type="text" value="">
</div></div>
```