### PR TITLE
Adjusted active tab font color.

### DIFF
--- a/static/sass/custom/taskpresenter.scss
+++ b/static/sass/custom/taskpresenter.scss
@@ -3,7 +3,7 @@
 }
 
 .nav-tabs>li>a, .nav-tabs>li>a:hover, .nav-tabs>li>a:focus {
-  color: #c0c0c0;
+  color: #606060;
   border: 1px solid #f0f0f0;
   border-bottom: none;
 }
@@ -15,12 +15,5 @@
 }
 
 li.tab-nav-collapse-expand.tab-link a {
-  color: #3AB0D5;
   border: none;
-
-  a:hover {
-    cursor: pointer;
-    text-decoration: none;
-    background-color: #F5F7F7;
-  }
 }


### PR DESCRIPTION
- Adjusted font color for non-active tabs to not appear disabled.

Inactive tabs currently appear disabled, in font color. This PR darkens the font.

Should we make the active tab font color black and non-active tabs blue to follow Bootstrap's [default](https://getbootstrap.com/docs/4.0/components/navs/#javascript-behavior) tab color?

#### Bootstrap Tabs

![bootstrap](https://user-images.githubusercontent.com/50708624/72101647-31131f80-32f3-11ea-9e97-c3cc046b38ca.png)

## Screenshots

### New Tabs

![after-1](https://user-images.githubusercontent.com/50708624/72100915-851d0480-32f1-11ea-8294-c377b8b31886.png)
![after-2](https://user-images.githubusercontent.com/50708624/72100916-851d0480-32f1-11ea-9cb7-4202e0666f7d.png)

### Old Tabs

![before-1](https://user-images.githubusercontent.com/50708624/72100919-8817f500-32f1-11ea-95a0-6d13ae2791a5.png)
![before-2](https://user-images.githubusercontent.com/50708624/72100920-8817f500-32f1-11ea-9d29-88952bdcead7.png)
