### PR TITLE
Fix table component bug - add initial values

### DIFF
--- a/static/src/components/builder/components/Table/checkboxInputColumnTemplate.html
+++ b/static/src/components/builder/components/Table/checkboxInputColumnTemplate.html
@@ -1,1 +1,1 @@
-<checkbox-input :row="props.row" pyb-table-answer="{{name}}"></checkbox-input>
+<checkbox-input :row="props.row" :initial-value="props.row.{{name}}" pyb-table-answer="{{name}}"></checkbox-input>

--- a/static/src/components/builder/components/Table/textInputColumnTemplate.html
+++ b/static/src/components/builder/components/Table/textInputColumnTemplate.html
@@ -1,1 +1,1 @@
-<text-input :row="props.row" pyb-table-answer="{{name}}"></text-input>
+<text-input :row="props.row" :initial-value="props.row.{{name}}" pyb-table-answer="{{name}}"></text-input>

--- a/static/src/components/builder/utils.js
+++ b/static/src/components/builder/utils.js
@@ -149,7 +149,7 @@ export default {
         const columnComponent =
         `<!--
             Please enter you custom component in this area.
-            Ensure to add these props :row="props.row" :initial-value="props.row.${col.name} "pyb-table-answer="${col.name}"
+            Ensure to add these props :row="props.row" :initial-value="props.row.${col.name}" pyb-table-answer="${col.name}"
          -->\n`;
 
         slots.push(

--- a/static/src/components/builder/utils.js
+++ b/static/src/components/builder/utils.js
@@ -149,7 +149,7 @@ export default {
         const columnComponent =
         `<!--
             Please enter you custom component in this area.
-            Ensure to add these props :row="props.row" pyb-table-answer="${col.name}"
+            Ensure to add these props :row="props.row" :initial-value="props.row.${col.name} "pyb-table-answer="${col.name}"
          -->\n`;
 
         slots.push(

--- a/static/src/test/utils.spec.js
+++ b/static/src/test/utils.spec.js
@@ -156,9 +156,9 @@ it('getTableInputCode for TABLE', () => {
   expect(componentCode.includes('"testColComponentCheckboxInput": "Checkbox Input Header Column"')).toBeTruthy();
 
   expect(componentCode.includes(`<div slot="testColComponentTextInput" slot-scope="props">`)).toBeTruthy();
-  expect(componentCode.includes(`<text-input :row="props.row" pyb-table-answer="testColComponentTextInput"></text-input>`)).toBeTruthy();
+  expect(componentCode.includes(`<text-input :row="props.row" :initial-value="props.row.testColComponentTextInput" pyb-table-answer="testColComponentTextInput"></text-input>`)).toBeTruthy();
   expect(componentCode.includes(`<div slot="testColComponentCheckboxInput" slot-scope="props">`)).toBeTruthy();
-  expect(componentCode.includes(`<checkbox-input :row="props.row" pyb-table-answer="testColComponentCheckboxInput"></checkbox-input>`)).toBeTruthy();
+  expect(componentCode.includes(`<checkbox-input :row="props.row" :initial-value="props.row.testColComponentCheckboxInput" pyb-table-answer="testColComponentCheckboxInput"></checkbox-input>`)).toBeTruthy();
 });
 
 it('getTableInputCode for TABLE with static data', () => {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<2942>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-2942

**Describe your changes**
Add `:initial-value` attribute to table components