### PR TITLE
fix typo and default column_id

### DIFF
--- a/static/src/components/builder/components/Table/TableForm.vue
+++ b/static/src/components/builder/components/Table/TableForm.vue
@@ -126,7 +126,7 @@
                 class="form-group"
               >
                 <label for="table-answer-name">
-                  Table Answer field Name | <span class="label-tip">he field where the worker's answers for the table are stored. Can be JSON path like a.b.c.</span>
+                  Table Answer field Name | <span class="label-tip">The field where the worker's answers for the table are stored. Can be JSON path like a.b.c.</span>
                 </label>
                 <input
                   id="table-answer-name"

--- a/static/src/components/builder/store/modules/table.js
+++ b/static/src/components/builder/store/modules/table.js
@@ -80,7 +80,7 @@ export const initialState = () => {
     id: utils.uniqueID(),
     name: { value: '', isDirty: false },
     data: { value: '', isVariable: true, isDirty: false },
-    columnId: { value: '', isDirty: false },
+    columnId: { value: '__col_id', isDirty: false },
     enableAddRows: { value: false, isDirty: false },
     addButtonAfterTable: { value: true, isDirty: false },
     addButtonBeforeTable: { value: false, isDirty: false },


### PR DESCRIPTION
![Screen Shot 2020-03-23 at 4 10 11 PM](https://user-images.githubusercontent.com/22711119/77358793-e2392b80-6d20-11ea-91e7-333e203f2193.png)

We say `column_id` is optional , with a default value '__col_id', but we do not have default value here.