### PR TITLE
Fix for announcements not rendering Markdown format.

### DIFF
--- a/templates/_flash_messages.html
+++ b/templates/_flash_messages.html
@@ -17,7 +17,7 @@
         </div>
         <div class="panel-body" style="word-wrap: break-word;">
             <p>
-            {{message.body | safe}}
+            {{message.body | markdown}}
             </p>
             <div>
                 <div class="btn btn-large btn-warning pull-right">Dismiss</div>


### PR DESCRIPTION
- Added fix for Markdown formatting of announcement messages.

*This fix applies the same Markdown formatting as that used in the [announcement.html](https://github.com/bloomberg/pybossa-default-theme/blob/master/templates/admin/announcement.html#L27) template on the Admin screen.*

## Screenshots

#### Fixed

![fix](https://user-images.githubusercontent.com/50708624/78050771-be8e6a80-734a-11ea-94f4-f793d7a3eb95.png)

#### Original

![notification-bad-format](https://user-images.githubusercontent.com/50708624/78050775-bfbf9780-734a-11ea-90da-7abc79761ddf.png)

