### PR TITLE
RDISCROWD-2967: Remove webhook field from update form

### DIFF
--- a/templates/projects/update.html
+++ b/templates/projects/update.html
@@ -52,7 +52,6 @@
         {% if 'data_access' in form %}
             {{ render_select2_field(form.data_access, config.DATA_ACCESS_MESSAGE.replace('SHORT_NAME', project.short_name) if config.DATA_ACCESS_MESSAGE else None) }}
         {% endif %}
-        {{ render_field(form.webhook) }}
         <div class="form-actions">
             <button type="submit" name='btn' value="Save the changes" class="btn btn-primary">{{_('Save the changes')}}</button>
         </div>


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-2967*

**Describe your changes**
I removed line line  55, {{ render_field(form.webhook) }}, from update.html to hide the webhook entry field which is not currently being used.       

## Screenshots
### Before
![webhook](https://user-images.githubusercontent.com/4377042/80257803-ba0a5880-864f-11ea-992a-d32c6fd59934.png)

### After
<img width="930" alt="webhook_removed" src="https://user-images.githubusercontent.com/4377042/80257813-be367600-864f-11ea-8879-6a53b6b2862d.png">
