### PR TITLE
RDISCROWD-3031 - default optout L1 projects

### DIFF
--- a/templates/projects/js/amp_store.js
+++ b/templates/projects/js/amp_store.js
@@ -1,0 +1,18 @@
+<script type="text/javascript">
+$(document).ready(function () {
+  $('#input_data_class').change(function () {
+      if ($('#input_data_class').val().includes('L1')){
+          optOutAmpStore();
+      }
+  });
+  $('#output_data_class').change(function () {
+      if ($('#output_data_class').val().includes('L1')){
+          optOutAmpStore();
+      }
+  });
+});
+
+function optOutAmpStore() {
+  document.getElementById("amp_store").checked = false;
+}
+</script>

--- a/templates/projects/js/amp_store.js
+++ b/templates/projects/js/amp_store.js
@@ -1,14 +1,15 @@
 <script type="text/javascript">
-$(document).ready(function () {
-  $('#input_data_class').change(function () {
-      if ($('#input_data_class').val().includes('L1')){
-          optOutAmpStore();
-      }
+$(function() {
+  let dataClassification = 'L1';
+  $('#input_data_class').change(function (e) {
+    if ($(e.target).val().includes(dataClassification)) {
+      optOutAmpStore();
+    }
   });
-  $('#output_data_class').change(function () {
-      if ($('#output_data_class').val().includes('L1')){
-          optOutAmpStore();
-      }
+  $('#output_data_class').change(function (e) {
+    if ($(e.target).val().includes(dataClassification)) {
+      optOutAmpStore();
+    }
   });
 });
 

--- a/templates/projects/new.html
+++ b/templates/projects/new.html
@@ -18,6 +18,7 @@
         <form id="create-project-form" method="post" action="{{ url_for('project.new')}}" enctype="multipart/form-data"}}>
         {{ form.hidden_tag() }}
         <fieldset>
+            {% include "projects/js/amp_store.js" %}
             {{ render_field(form.name, class_="span4", placeholder=_('The name of the project')) }}
             {{ render_field(form.short_name, class_="span4", placeholder=_('Short name or slug for the project'), label_text=_('Project slug:')) }}
             {{ render_field(form.long_description, class_="span4", rows="13", placeholder=_('Explain your project

--- a/templates/projects/update.html
+++ b/templates/projects/update.html
@@ -27,6 +27,7 @@
 <h2>{{_('Update project details')}}</h2>
 <form id="create-project-form" method="post" action="{{ url_for('project.update', short_name = project.short_name) }}">
     <fieldset>
+        {% include "projects/js/amp_store.js" %}
         {{ form.hidden_tag() }}
         {{ render_field(form.name, class_="input-xlarge", placeholder=_('The name of the project')) }}
         {{ render_field(form.description, class_="input-xlarge", placeholder=_('Give some details about the project')) }}


### PR DESCRIPTION
https://jira.prod.bloomberg.com/browse/RDISCROWD-3031

- add js code to /update and /new page so that if the user chooses L1 for either input_data_class or output_data_class, uncheck opt-in checkbox

Re: https://github.com/bloomberg/pybossa/pull/481