### PR TITLE
RDISCROWD-3134: Hide Password in Project Settings Password Field 

### DIFF
--- a/templates/projects/new.html
+++ b/templates/projects/new.html
@@ -28,7 +28,7 @@
 · Will you help make a difference? Explain to the volunteers why their contribution is essential and how the result of your project can help change things!
 
 (you can use Markdown to give format to your description!)')) }}
-            {{ render_field(form.password, class_="span4 password", placeholder=_('Enter project password')) }}
+            {{ render_field(form.password, type="password", class_="span4 password", placeholder=_('Enter project password')) }}
             <div id="password-requirements">{{ form.password.render_kw.placeholder }}</div>
             {{ render_field(form.product) }}
             {{ render_field(form.subproduct) }}

--- a/templates/projects/update.html
+++ b/templates/projects/update.html
@@ -50,7 +50,7 @@
             {{ render_checkbox_field(form.sync_enabled, class_="", tooltip=_('Check if you want to enable project syncing')) }}
         {% endif %}
         <a name="data-access"></a>
-        {{ render_field(form.password, class_="password", placeholder="Leave blank to maintain set password") }}
+        {{ render_field(form.password, type="password", class_="password", placeholder="Leave blank to maintain set password") }}
         <div id="password-requirements">{{ form.password.render_kw.placeholder }}</div>
         {% if 'data_access' in form %}
             {{ render_select2_field(form.data_access, config.DATA_ACCESS_MESSAGE.replace('SHORT_NAME', project.short_name) if config.DATA_ACCESS_MESSAGE else None) }}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3134

**Describe your changes**
The ProjectCommonForm and ProjectUpdateForm passwords were both TextFields instead of Password fields. I changed this and also added type="password" to the render_field in the html for projects/new.html and projects/update.html. 

**Testing performed**
I checked to see that these fields were rendering correctly locally.

***Screenshot***
<img width="926" alt="Screenshot 2020-06-19 at 08 14 30" src="https://user-images.githubusercontent.com/4377042/85131550-0499f280-b205-11ea-822c-56bff4e7cf03.png">

