### PR TITLE
RDISCROWD-3162: removing news block from admin/index.html

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -49,18 +49,5 @@
         {{ render_project_card_option(project, upload_method, title=_('Stats Dashboard'), explanation=_('Additional site-wide stats'), link=url_for('admin.management_dashboard'), link_action_text=_('Stats'), icon='info') }}
     </div>
     {% endif %}
-</div>
-{% if current_user.admin %}
-<div class="row">
-    <div class="col-md-12">
-        <h4>{{_('Latest news from PyBossa')}}</h4>
-        <ul class="news">
-            {% for new in news %}
-            <li><strong>{{new.updated[0:10]}}</strong> {% if 'github' in new.links[0].href %} <span class="label label-info">{{_('New PyBossa version')}}</span> {% else %} <span class="label label-default">{{_('New SciFabric Blog Post')}}</span> {% endif %}<a target="_blank" href="{{new.links[0].href}}">{{new.title}}</a></li>
-            {% endfor %}
-        </ul>
-</div>
-{% endif %}
-</div>
 </div> <!-- container -->
 {% endblock %}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3162

**Describe your changes**
- removed news block from admin/index.html

**Testing performed**
Loaded the changed page locally and saw that the text was now removed. 

Before: 
![image](https://user-images.githubusercontent.com/7538079/85332521-164df500-b4a6-11ea-8b5d-4ae83cdd2d78.png)

After:
![image](https://user-images.githubusercontent.com/7538079/85331948-0da8ef00-b4a5-11ea-82ad-dd75e55669eb.png)
