### PR TITLE
RDISCROWD-3216: BSSO account creation alert

### DIFF
--- a/templates/account/email/adminbssonotification.html
+++ b/templates/account/email/adminbssonotification.html
@@ -1,7 +1,7 @@
 {% block page_content %}
     <h1>{{access_type}} access on {{ config.BRAND }}</h1>
     <p>Hello, </p>
-    <p>{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by BSSO auto-account generation.
+    <p>A {{ config.BRAND }} account for {{username}} has been auto-generated using information from BSSO. Please check their user type.
     {% if is_qa %}
     (QA Version)
     {% endif %} at <a href={{server_url}}>{{server_url}}</a>.</p>

--- a/templates/account/email/adminbssonotification.html
+++ b/templates/account/email/adminbssonotification.html
@@ -1,7 +1,7 @@
 {% block page_content %}
     <h1>{{access_type}} access on {{ config.BRAND }}</h1>
     <p>Hello, </p>
-    <p>{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by {{current_user.fullname}}.
+    <p>{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by BSSO auto-account generation.
     {% if is_qa %}
     (QA Version)
     {% endif %} at <a href={{server_url}}>{{server_url}}</a>.</p>

--- a/templates/account/email/adminbssonotification.html
+++ b/templates/account/email/adminbssonotification.html
@@ -1,0 +1,8 @@
+{% block page_content %}
+    <h1>{{access_type}} access on {{ config.BRAND }}</h1>
+    <p>Hello, </p>
+    <p>{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by {{current_user.fullname}}.
+    {% if is_qa %}
+    (QA Version)
+    {% endif %} at <a href={{server_url}}>{{server_url}}</a>.</p>
+{% endblock %}

--- a/templates/account/email/adminbssonotification.md
+++ b/templates/account/email/adminbssonotification.md
@@ -1,0 +1,7 @@
+# {{access_type}} access on {{ config.BRAND }}
+
+Hello,
+
+{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by {{current_user.fullname}}.
+
+{% if is_qa %} (QA Version) {% endif %} at [{{server_url}}]({{server_url}}).

--- a/templates/account/email/adminbssonotification.md
+++ b/templates/account/email/adminbssonotification.md
@@ -2,6 +2,6 @@
 
 Hello,
 
-{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by {{current_user.fullname}}.
+{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by BSSO auto-account generation.
 
 {% if is_qa %} (QA Version) {% endif %} at [{{server_url}}]({{server_url}}).

--- a/templates/account/email/adminbssonotification.md
+++ b/templates/account/email/adminbssonotification.md
@@ -2,6 +2,5 @@
 
 Hello,
 
-{{username}} has been granted {{access_type}} privileges on {{ config.BRAND }} by BSSO auto-account generation.
-
+A {{ config.BRAND }} account for {{username}} has been auto-generated using information from BSSO. Please check their user type.
 {% if is_qa %} (QA Version) {% endif %} at [{{server_url}}]({{server_url}}).


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
https://jira.prod.bloomberg.com/browse/RDISCROWD-3216

**Describe your changes**
Tim requested that an email be sent to his account when an account is created via the BSSO route, as well as to display a flash message to the user indicating that a new account has been created for them using BSSO. This required adding the conditional to send the message, the message creation function, the message html/md, and the related test.

**Testing performed**
I added a new test and also tested locally.

<img width="866" alt="Screenshot 2020-06-23 at 09 15 46" src="https://user-images.githubusercontent.com/4377042/85445762-bcab0080-b561-11ea-8ad7-7c93d9194937.png">