### PR TITLE
add warning to external config

### DIFF
--- a/templates/projects/external_config.html
+++ b/templates/projects/external_config.html
@@ -3,6 +3,7 @@
 {% set active_link  = "settings" %}
 {% set section = _('External Configurations') %}
 {% from "_formhelpers.html" import render_form %}
+{}
 
 {% block projectcontent %}
 {% if not forms %}
@@ -10,13 +11,14 @@
 {% else %}
 
 <p style="color:#FF0000";>{{_('WARNING: INVALID FILE LOCATION OR PERMISSIONS MAY RESULT IN <b>LOSS OF DATA</b>.')}}</p>
-<p>{{_('Before starting your job please confirm the following:')}}</p>
+<p>{{_('Before starting your project please confirm the following:')}}</p>
 <ul>
-    <li>The bucket and/or directory you plan to access already exists (Gigwork will not create this for you)</li>
+    <li>The bucket and/or directory you plan to access already exists ({{brand}} will not create this for you)</li>
     <li>You have permission to access the directories and/or buckets you plan to use</li>
     <li>You have spelled the bucket and/or directory name correctly</li>
 </ul>
-<p>For more information on these settings, please consult the <a href="https://bbgithub.dev.bloomberg.com/pages/GIGwork/private-gigwork-cheat-sheet.html#important-settings-external-configurations">External Configurations documentation</a>.</p>
+
+<p>For more information on these settings, please consult the <a href={{config.EXT_CONFIG_DOCS}}>External Configurations documentation</a>.</p>
 
 {% for (form_name, display, form) in forms %}
     <h3>{{display}}</h3>

--- a/templates/projects/external_config.html
+++ b/templates/projects/external_config.html
@@ -3,7 +3,6 @@
 {% set active_link  = "settings" %}
 {% set section = _('External Configurations') %}
 {% from "_formhelpers.html" import render_form %}
-{}
 
 {% block projectcontent %}
 {% if not forms %}

--- a/templates/projects/external_config.html
+++ b/templates/projects/external_config.html
@@ -17,7 +17,9 @@
     <li>You have spelled the bucket and/or directory name correctly</li>
 </ul>
 
+{% if config.EXT_CONFIG_DOCS %}
 <p>For more information on these settings, please consult the <a href={{config.EXT_CONFIG_DOCS}}>External Configurations documentation</a>.</p>
+{% endif %}
 
 {% for (form_name, display, form) in forms %}
     <h3>{{display}}</h3>

--- a/templates/projects/external_config.html
+++ b/templates/projects/external_config.html
@@ -9,6 +9,15 @@
 <h3>{{_('No external services have been configured')}}</h3>
 {% else %}
 
+<p style="color:#FF0000";>{{_('WARNING: INVALID FILE LOCATION OR PERMISSIONS MAY RESULT IN <b>LOSS OF DATA</b>.')}}</p>
+<p>{{_('Before starting your job please confirm the following:')}}</p>
+<ul>
+    <li>The bucket and/or directory you plan to access already exists (Gigwork will not create this for you)</li>
+    <li>You have permission to access the directories and/or buckets you plan to use</li>
+    <li>You have spelled the bucket and/or directory name correctly</li>
+</ul>
+<p>For more information on these settings, please consult the <a href="https://bbgithub.dev.bloomberg.com/pages/GIGwork/private-gigwork-cheat-sheet.html#important-settings-external-configurations">External Configurations documentation</a>.</p>
+
 {% for (form_name, display, form) in forms %}
     <h3>{{display}}</h3>
     {{render_form(form, form_id=form_name, action_url=url_for('project.ext_config', short_name=project.short_name), action_text='Submit', class_='', btn_name=form_name, btn_class='btn btn-default', btn_value=None)}}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-3304*

**Describe your changes**
I added the warning text to the external configuration UI. 

**Testing performed**
I checked in the UI locally and it looks good.

**Additional context**
Usage
Edit settings_local.py and set a value as shown below.

EXT_CONFIG_DOCS = [Link to External Configuration Documentation]

Screenshots available in JIRA ticket: 
https://jira.prod.bloomberg.com/browse/RDISCROWD-3304
