### PR TITLE
RDISCROWD-3503 Replace Bintray service from pybossa-vue Jenkins job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     before_install:
     - cd static/src && ls
     install:
-    - npm config set @dtwebservices:registry="https://api.bintray.com/npm/bloomberg/gigwork///"
+    - npm config set @dtwebservices:registry="https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos"
     - yarn install
     - ls ./node_modules
     - yarn test


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-3503*

**Describe your changes**
Replace Bintray npm repo URL with artifactory URL

**Testing performed**
Test locally; But still need to test after merging to master

**Additional context**
This might not be a proper solution. Likely we still need a public npm repo.

Related [PR](https://bbgithub.dev.bloomberg.com/GIGwork/pybossa-vue/pull/102)