### PR TITLE
RDISCROWD-3556 replace Bintray with AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
     before_install:
     - cd static/src && ls
     install:
-    - npm config set @dtwebservices:registry="https://api.bintray.com/npm/bloomberg/gigwork///"
+    - TASK_PRESENTER_VERSION=$(node -p "require('./package.json').devDependencies['@dtwebservices/task-presenter-components']")
+    - npm install https://s3.amazonaws.com/cf-s3uploads/pybv/${TASK_PRESENTER_VERSION}/task-presenter-components.tgz
     - yarn install
     - ls ./node_modules
     - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ matrix:
     before_install:
     - cd static/src && ls
     install:
-    - TASK_PRESENTER_VERSION=$(node -p "require('./package.json').devDependencies['@dtwebservices/task-presenter-components']")
-    - npm install https://s3.amazonaws.com/cf-s3uploads/pybv/${TASK_PRESENTER_VERSION}/task-presenter-components.tgz
+    - npm config set @dtwebservices:registry="https://api.bintray.com/npm/bloomberg/gigwork///"
     - yarn install
     - ls ./node_modules
     - yarn test

--- a/static/src/package.json
+++ b/static/src/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "editor.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bloomberg/pybossa-default-theme.git"
+  },
   "scripts": {
     "watch": "webpack -w -d",
     "test": "jest",


### PR DESCRIPTION
Issue number of the reported bug or feature request: RDISCROWD-3556

Describe your changes
Replacing Bintray npm repo URL with AWS S3. It first grabs the @dtwebservices/task-presenter-components version from [package.json](https://github.com/bloomberg/pybossa-default-theme/blob/ab51a7639da52ac08b11a545acd7640ecfe3e900/static/src/package.json#L15) file. Then it executes npm install <tarball-url> command, which will install task-presenter-components as well as update its version in the package.json file with the aws s3 url.

Testing performed
Test locally

Related [PR](https://bbgithub.dev.bloomberg.com/GIGwork/pybossa-vue/pull/103)