### PR TITLE
Additional help added to external configuration page.

### DIFF
--- a/templates/projects/external_config.html
+++ b/templates/projects/external_config.html
@@ -10,12 +10,14 @@
 {% else %}
 
 <p style="color:#FF0000";>{{_('WARNING: INVALID FILE LOCATION OR PERMISSIONS MAY RESULT IN <b>LOSS OF DATA</b>.')}}</p>
+{% if config.EXT_CONFIG_TIPS %}
 <p>{{_('Before starting your project please confirm the following:')}}</p>
-<ul>
-    <li>The bucket and/or directory you plan to access already exists ({{brand}} will not create this for you)</li>
-    <li>You have permission to access the directories and/or buckets you plan to use</li>
-    <li>You have spelled the bucket and/or directory name correctly</li>
-</ul>
+<ol>
+	{% for tip in config.EXT_CONFIG_TIPS %}
+    <li>{{tip}}</li>
+    {% endfor %}
+</ol>
+{% endif %}
 
 {% if config.EXT_CONFIG_DOCS %}
 <p>For more information on these settings, please consult the <a href={{config.EXT_CONFIG_DOCS}}>External Configurations documentation</a>.</p>


### PR DESCRIPTION
- Moved external configuration help to settings_local.py under `EXT_CONFIG_TIPS`.
- Defined additional help for external configuration settings for buckets.

```python
EXT_CONFIG_TIPS = [
    'The bucket you plan to access already exists (GIGwork will not create this for you).',
    'You have spelled the bucket name correctly.',
    'You have permission to access the bucket you plan to use.',
    'You have granted read/write access on your bucket to _____.'
]
```

## Screenshots

`EXT_CONFIG_TIPS` is an array of strings to render.

![bcos-1](https://user-images.githubusercontent.com/50708624/96746864-9e310680-1395-11eb-8f18-08b281f359a0.png)

If `EXT_CONFIG_TIPS` is not defined, the tips are omitted.

![bcos-2](https://user-images.githubusercontent.com/50708624/96746865-9f623380-1395-11eb-89bb-8e7d565b7eb1.png)

_____
*The External Configurations page tends to be a problematic area with higher user mistakes. Adding detailed help items may reduce user error.*