### PR TITLE
RDISCROWD-4451 Collapsible left-nav and responsive browse tasks table

### DIFF
--- a/static/css/task_browse.css
+++ b/static/css/task_browse.css
@@ -76,8 +76,8 @@
 }
 
 .task-pagination {
-    margin-left: 8px;
     font-size: 12px;
+    margin-bottom: 3px;
     color: #606060;
 }
 
@@ -88,4 +88,8 @@
 .make-gold-cell {
     width: 104px;
     margin-top: 4px;
+}
+
+#tasksBrowseControls>ul>li:last-child {
+    padding-left: 0;
 }

--- a/static/css/task_browse.css
+++ b/static/css/task_browse.css
@@ -74,3 +74,18 @@
     top:40%;
     font-size: 32px;
 }
+
+.task-pagination {
+    margin-left: 8px;
+    font-size: 12px;
+    color: #606060;
+}
+
+.table>thead>tr>th, .table>thead>tr>td, .table>tbody>tr>th, .table>tbody>tr>td, .table>tfoot>tr>th, .table>tfoot>tr>td {
+    padding: 0;
+}
+
+.make-gold-cell {
+    width: 104px;
+    margin-top: 4px;
+}

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,0 +1,63 @@
+$(function() {
+  const leftNavCollapseKey = 'leftNavCollapse';
+  const menu = $('#menu');
+  const btnCollapse = menu.find('a.btn-expand-collapse');
+
+  function setCookie(name, value, days=365) {
+    var expires = "";
+    if (days) {
+      var date = new Date();
+      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = name + "=" + (value || "") + expires + "; path=/";
+  }
+
+  function getCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+  }
+
+  const leftNavTooltips = () => {
+    // Set the tooltip to show the menu item text.
+    menu.find('a.list-group-item').each((index, e) => {
+      $(e).attr('title', menu.hasClass('collapsed') ? $(e).text() : '');
+    });
+  };
+
+  const onCollapseLeftNav = () => {
+    // Toggle collapsed state of left-nav menu.
+    menu.toggleClass('collapsed');
+    // Hide right chevrons of left-nav menu items.
+    menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
+    // Toggle the chevron in the collapse button right/left or left/right.
+    btnCollapse.find('i').toggleClass('fa-chevron-left fa-chevron-right');
+    // Set tooltips on left-nav menu.
+    leftNavTooltips();
+    // Expand width of the page when left-nav is collapsed.
+    $('.container').toggleClass('w-100');
+    // Save settings, use a cookie for smooth rendering of page upon load from server.
+    const isCollapse = getCookie('leftNavCollapse') || false;
+    setCookie('leftNavCollapse', !isCollapse);
+  };
+
+  const initializeLeftNav = () => {
+    // Initialize left-nav menu state.
+    const isCollapse = getCookie('leftNavCollapse');
+    isCollapse && leftNavTooltips();
+
+    // Setup event handler on left-nav collapse button click.
+    btnCollapse.click(onCollapseLeftNav);
+
+    // Enable animation effort on left-nav collapse.
+    $('.container').addClass('animated');
+  };
+
+  initializeLeftNav();
+});

--- a/static/sass/custom/project.scss
+++ b/static/sass/custom/project.scss
@@ -67,9 +67,9 @@ legend.import {
 
 #menu {
   overflow: hidden;
-  -webkit-transition: all 0.1s ease-in-out;
-  -moz-transition: all 0.1s ease-in-out;
-  transition: all 0.1s ease-in-out;
+  -webkit-transition: width 0.1s ease-in-out;
+  -moz-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
   max-width: 250px;
 }
 

--- a/static/sass/custom/project.scss
+++ b/static/sass/custom/project.scss
@@ -85,6 +85,10 @@ legend.import {
   color: #3AB0D5;
 }
 
+#menu a.active i.nav-icon {
+  color: white;
+}
+
 .list-group-item.btn-expand-collapse i {
     color: #c0c0c0;
 }

--- a/static/sass/custom/project.scss
+++ b/static/sass/custom/project.scss
@@ -55,7 +55,7 @@ legend.import {
   font-size: 24px;
 }
 
-.container {
+.container.animated, #menu.animated {
   -webkit-transition: width 0.1s ease-in-out;
   -moz-transition: width 0.1s ease-in-out;
   transition: width 0.1s ease-in-out;
@@ -67,41 +67,43 @@ legend.import {
 
 #menu {
   overflow: hidden;
-  -webkit-transition: width 0.1s ease-in-out;
-  -moz-transition: width 0.1s ease-in-out;
-  transition: width 0.1s ease-in-out;
   max-width: 250px;
   min-width: 220px;
-}
 
-#menu.collapsed {
+  &.collapsed {
     width: 75px;
     min-width: 75px;
+
+    .nav-label {
+      display: none;
+    }
   }
 
-#menu.collapsed .nav-label {
-  display: none;
+  i.nav-icon {
+    color: #3AB0D5;
+  }
+
+  a.active i.nav-icon {
+    color: white;
+  }
+
+  a.list-group-item .icon {
+    margin-top: 3px;
+  }
 }
 
-#menu i.nav-icon {
-  color: #3AB0D5;
-}
-
-#menu a.active i.nav-icon {
-  color: white;
-}
-
-#menu a.list-group-item .icon {
-  margin-top: 3px;
-}
-
-.list-group-item.btn-expand-collapse i {
+.list-group-item.btn-expand-collapse {
+  i {
     color: #c0c0c0;
-}
+  }
 
-.list-group-item.btn-expand-collapse:hover i,
-.list-group-item.btn-expand-collapse:focus i {
+  &:hover i {
     color: #666;
+  }
+
+  &:focus {
+    background-color: white;
+  }
 }
 
 .clear {

--- a/static/sass/custom/project.scss
+++ b/static/sass/custom/project.scss
@@ -55,11 +55,22 @@ legend.import {
   font-size: 24px;
 }
 
+.container {
+  -webkit-transition: width 0.1s ease-in-out;
+  -moz-transition: width 0.1s ease-in-out;
+  transition: width 0.1s ease-in-out;
+}
+
+.w-100 {
+  width: 100%;
+}
+
 #menu {
   overflow: hidden;
   -webkit-transition: all 0.1s ease-in-out;
   -moz-transition: all 0.1s ease-in-out;
   transition: all 0.1s ease-in-out;
+  max-width: 250px;
 }
 
 #menu.collapsed {

--- a/static/sass/custom/project.scss
+++ b/static/sass/custom/project.scss
@@ -45,3 +45,40 @@ legend.import {
 .pointer {
   cursor: pointer;
 }
+
+.btn-expand-collapse {
+    text-align: center;
+}
+
+.fa.fa-angle-double-left,
+.fa.fa-angle-double-right {
+  font-size: 24px;
+}
+
+#menu {
+  overflow: hidden;
+  -webkit-transition: all 0.1s ease-in-out;
+  -moz-transition: all 0.1s ease-in-out;
+  transition: all 0.1s ease-in-out;
+}
+
+#menu.collapsed {
+    width: 75px;
+}
+
+#menu.collapsed .nav-label {
+  display: none;
+}
+
+#menu i.nav-icon {
+  color: #3AB0D5;
+}
+
+.list-group-item.btn-expand-collapse i {
+    color: #c0c0c0;
+}
+
+.list-group-item.btn-expand-collapse:hover i,
+.list-group-item.btn-expand-collapse:focus i {
+    color: #666;
+}

--- a/static/sass/custom/project.scss
+++ b/static/sass/custom/project.scss
@@ -71,11 +71,13 @@ legend.import {
   -moz-transition: width 0.1s ease-in-out;
   transition: width 0.1s ease-in-out;
   max-width: 250px;
+  min-width: 220px;
 }
 
 #menu.collapsed {
     width: 75px;
-}
+    min-width: 75px;
+  }
 
 #menu.collapsed .nav-label {
   display: none;
@@ -89,6 +91,10 @@ legend.import {
   color: white;
 }
 
+#menu a.list-group-item .icon {
+  margin-top: 3px;
+}
+
 .list-group-item.btn-expand-collapse i {
     color: #c0c0c0;
 }
@@ -96,4 +102,8 @@ legend.import {
 .list-group-item.btn-expand-collapse:hover i,
 .list-group-item.btn-expand-collapse:focus i {
     color: #666;
+}
+
+.clear {
+  clear: both;
 }

--- a/templates/_navbar.html
+++ b/templates/_navbar.html
@@ -1,10 +1,6 @@
 <div class="navbar navbar-default navbar-fixed-top">
     <div class="navbar-inner" style="min-height:100px;">
-    {% if request.cookies.leftNavCollapse == "true" %}
-    <div class="container w-100">
-    {% else %}
-    <div class="container">
-    {% endif %}
+    <div class="container {{'w-100' if request.cookies.leftNavCollapse == 'true'}}">
         <div class="navbar-header">
             <a class="navbar-brand" href="{{ url_for('home.home') }}">
                 <img src="{{url_for('static',filename='img/' + logo)}}" alt="{{brand}}">

--- a/templates/_navbar.html
+++ b/templates/_navbar.html
@@ -1,6 +1,10 @@
 <div class="navbar navbar-default navbar-fixed-top">
     <div class="navbar-inner" style="min-height:100px;">
+    {% if request.cookies.leftNavCollapse == "true" %}
+    <div class="container w-100">
+    {% else %}
     <div class="container">
+    {% endif %}
         <div class="navbar-header">
             <a class="navbar-brand" href="{{ url_for('home.home') }}">
                 <img src="{{url_for('static',filename='img/' + logo)}}" alt="{{brand}}">

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -47,7 +47,7 @@
                 <span class='nav-label'>{{_('Info')}}</span>
             </div>
             <div class="icon">
-                <i class="fa fa-chevron-right pull-right"></i>
+                <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
             </div>
             <div class="clear"></div>
         </a>
@@ -60,7 +60,7 @@
                 </span>
             </div>
             <div class="icon">
-                <i class="fa fa-chevron-right pull-right"></i>
+                <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
             </div>
             <div class="clear"></div>
         </a>
@@ -73,7 +73,7 @@
                 <span class='nav-label'>{{_('Project Settings')}}</span>
             </div>
             <div class="icon">
-                <i class="fa fa-chevron-right pull-right"></i>
+                <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
             </div>
             <div class="clear"></div>
         </a>
@@ -86,7 +86,7 @@
                 <span class='nav-label'>{{_('Statistics')}}</span>
             </div>
             <div class="icon">
-                <i class="fa fa-chevron-right pull-right"></i>
+                <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
             </div>
             <div class="clear"></div>
         </a>
@@ -97,7 +97,7 @@
             <span class='nav-label'>{{_('Performance Stats')}}</span>
         </div>
         <div class="icon">
-            <i class="fa fa-chevron-right pull-right"></i>
+            <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
         </div>
         <div class="clear"></div>
     </a>
@@ -109,7 +109,7 @@
                 <span class='nav-label'>{{_('Audit Logs')}}</span>
             </div>
             <div class="icon">
-                <i class="fa fa-chevron-right pull-right"></i>
+                <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
             </div>
             <div class="clear"></div>
         </a>
@@ -122,14 +122,14 @@
                 <span class='nav-label'>{{_('Clone')}}</span>
             </div>
             <div class="icon">
-                <i class="fa fa-chevron-right pull-right"></i>
+                <i class="{{'fa fa-chevron-right' if request.cookies.leftNavCollapse != 'true'}} pull-right"></i>
             </div>
             <div class="clear"></div>
         </a>
     {% endif %}
 
     <a class="list-group-item btn-expand-collapse" href="#">
-        <i class="fa fa-chevron-left"></i>
+        <i class="fa {{'fa-chevron-left' if request.cookies.leftNavCollapse != 'true' else 'fa-chevron-right'}}"></i>
     </a>
 </div>
 <ul class="list-group" style="margin-top: 21px;">
@@ -162,11 +162,7 @@ $(function() {
     return null;
   }
 
-  const collapseLeftNav = () => {
-    // Hide right chevrons of left-nav menu items.
-    menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
-    // Toggle the chevron in the collapse button right/left or left/right.
-    btnCollapse.find('i').toggleClass('fa-chevron-left fa-chevron-right');
+  const leftNavTooltips = () => {
     // Set the tooltip to show the menu item text.
     menu.find('a.list-group-item').each((index, e) => {
       $(e).attr('title', menu.hasClass('collapsed') ? $(e).text() : '');
@@ -176,8 +172,12 @@ $(function() {
   const onCollapseLeftNav = () => {
     // Toggle collapsed state of left-nav menu.
     menu.toggleClass('collapsed');
-    // Event handler for clicking left-nav collapse button.
-    collapseLeftNav();
+    // Hide right chevrons of left-nav menu items.
+    menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
+    // Toggle the chevron in the collapse button right/left or left/right.
+    btnCollapse.find('i').toggleClass('fa-chevron-left fa-chevron-right');
+    // Set tooltips on left-nav menu.
+    leftNavTooltips();
     // Expand width of the page when left-nav is collapsed.
     $('.container').toggleClass('w-100');
     // Save settings, use a cookie for smooth rendering of page upon load from server.
@@ -188,7 +188,7 @@ $(function() {
   const initializeLeftNav = () => {
     // Initialize left-nav menu state.
     const isCollapse = getCookie('leftNavCollapse');
-    isCollapse && collapseLeftNav();
+    isCollapse && leftNavTooltips();
 
     // Setup event handler on left-nav collapse button click.
     btnCollapse.click(onCollapseLeftNav);

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -42,54 +42,89 @@
 
     {% if is_admin_or_subadmin_or_owner %}
         <a class="list-group-item {% if active_link=='info'%}active{% endif %}" href="{{url_for('project.details', short_name=project.short_name)}}">
-            <i class='nav-icon fa fa-info-circle'></i>
-            <span class='nav-label'>{{_('Info')}}</span>
-            <i class="fa fa-chevron-right pull-right"></i>
+            <div class="pull-left">
+                <i class='nav-icon fa fa-info-circle'></i>
+                <span class='nav-label'>{{_('Info')}}</span>
+            </div>
+            <div class="icon">
+                <i class="fa fa-chevron-right pull-right"></i>
+            </div>
+            <div class="clear"></div>
         </a>
 
         <a class="list-group-item {% if active_link=='tasks'%}active{% endif %}" href="{{url_for('project.tasks', short_name=project.short_name)}}">
-            <i class='nav-icon fa fa-tasks'></i>
-            <span class='nav-label'>
-                {{_('Tasks')}} {{daniel}}{% if task_subsection_1_text %}<a href="{{task_subsection_1}}">{{task_subsection_1_text}}</a>{% endif %}
-            </span>
-            <i class="fa fa-chevron-right pull-right"></i>
+            <div class="pull-left">
+                <i class='nav-icon fa fa-tasks'></i>
+                <span class='nav-label'>
+                    {{_('Tasks')}} {{daniel}}{% if task_subsection_1_text %}<a href="{{task_subsection_1}}">{{task_subsection_1_text}}</a>{% endif %}
+                </span>
+            </div>
+            <div class="icon">
+                <i class="fa fa-chevron-right pull-right"></i>
+            </div>
+            <div class="clear"></div>
         </a>
     {% endif %}
 
     {% if is_subadmin_and_owner_or_admin %}
         <a class="list-group-item {% if active_link=='settings'%}active{% endif %}" href="{{url_for('project.settings', short_name=project.short_name)}}">
-            <i class='nav-icon fa fa-cog'></i>
-            <span class='nav-label'>{{_('Project Settings')}}</span>
-            <i class="fa fa-chevron-right pull-right"></i>
+            <div class="pull-left">
+                <i class='nav-icon fa fa-cog'></i>
+                <span class='nav-label'>{{_('Project Settings')}}</span>
+            </div>
+            <div class="icon">
+                <i class="fa fa-chevron-right pull-right"></i>
+            </div>
+            <div class="clear"></div>
         </a>
     {% endif %}
 
     {% if is_admin_or_subadmin_or_owner %}
         <a class="list-group-item {% if active_link=='stats'%}active{% endif %}" href="{{url_for('project.show_stats', short_name=project.short_name)}}">
-            <i class='nav-icon fa fa-signal'></i>
-            <span class='nav-label'>{{_('Statistics')}}</span>
-            <i class="fa fa-chevron-right pull-right"></i>
+            <div class="pull-left">
+                <i class='nav-icon fa fa-signal'></i>
+                <span class='nav-label'>{{_('Statistics')}}</span>
+            </div>
+            <div class="icon">
+                <i class="fa fa-chevron-right pull-right"></i>
+            </div>
+            <div class="clear"></div>
         </a>
     {% endif %}
     <a class="list-group-item {% if active_link=='performancestats'%}active{% endif %}" href="{{url_for('project.show_performance_stats', short_name=project.short_name)}}">
-        <i class='nav-icon fa fa-star'></i>
-        <span class='nav-label'>{{_('Performance Stats')}}</span>
-        <i class="fa fa-chevron-right pull-right"></i>
+        <div class="pull-left">
+            <i class='nav-icon fa fa-star'></i>
+            <span class='nav-label'>{{_('Performance Stats')}}</span>
+        </div>
+        <div class="icon">
+            <i class="fa fa-chevron-right pull-right"></i>
+        </div>
+        <div class="clear"></div>
     </a>
 
     {% if is_subadmin_and_owner_or_admin %}
         <a class="list-group-item {% if active_link=='auditlog'%}active{% endif %}" href="{{url_for('project.auditlog', short_name=project.short_name)}}">
-            <i class='nav-icon fa fa-file'></i>
-            <span class='nav-label'>{{_('Audit Logs')}}</span>
-            <i class="fa fa-chevron-right pull-right"></i>
+            <div class="pull-left">
+                <i class='nav-icon fa fa-file'></i>
+                <span class='nav-label'>{{_('Audit Logs')}}</span>
+            </div>
+            <div class="icon">
+                <i class="fa fa-chevron-right pull-right"></i>
+            </div>
+            <div class="clear"></div>
         </a>
     {% endif %}
 
     {% if is_subadmin_or_admin %}
         <a class="list-group-item {% if active_link=='clone'%}active{% endif %}" href="{{url_for('project.clone', short_name=project.short_name)}}">
-            <i class='nav-icon fa fa-clone'></i>
-            <span class='nav-label'>{{_('Clone')}}</span>
-            <i class="fa fa-chevron-right pull-right"></i>
+            <div class="pull-left">
+                <i class='nav-icon fa fa-clone'></i>
+                <span class='nav-label'>{{_('Clone')}}</span>
+            </div>
+            <div class="icon">
+                <i class="fa fa-chevron-right pull-right"></i>
+            </div>
+            <div class="clear"></div>
         </a>
     {% endif %}
 

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -137,14 +137,43 @@
 </ul>
 <script>
 $(function() {
-  $('.btn-expand-collapse').click(function() {
-    const menu = $('#menu');
+  const leftNavCollapseKey = 'leftNavCollapse';
+  const menu = $('#menu');
+  const btnCollapse = menu.find('a.btn-expand-collapse');
 
+  const collapseLeftNav = () => {
+    // Toggle collapsed state of left-nav menu.
     menu.toggleClass('collapsed');
-    menu.find('a.btn-expand-collapse i').toggleClass('fa-chevron-left fa-chevron-right');
+    // Hide right chevrons of left-nav menu items.
     menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
+    // Toggle the chevron in the collapse button right/left or left/right.
+    btnCollapse.find('i').toggleClass('fa-chevron-left fa-chevron-right');
+    // Expand width of the page when left-nav is collapsed.
     $('.container').toggleClass('w-100');
-  });
+  };
+
+  const onCollapseLeftNav = () => {
+    // Event handler for clicking left-nav collapse button.
+    collapseLeftNav();
+    // Save settings.
+    localStorage[leftNavCollapseKey] = !JSON.parse(localStorage[leftNavCollapseKey] || '""');
+  };
+
+  const initializeLeftNav = () => {
+    // Initialize left-nav menu state.
+    JSON.parse(localStorage[leftNavCollapseKey] || '""') && collapseLeftNav();
+
+    // Setup event handler on left-nav collapse button click.
+    btnCollapse.click(onCollapseLeftNav);
+
+    // Enable animation effort on left-nav collapse.
+    setTimeout(() => {
+      menu.addClass('animated');
+      $('.container').addClass('animated');
+    }, 1);
+  };
+
+  initializeLeftNav();
 });
 </script>
 {% endmacro %}

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -141,9 +141,28 @@ $(function() {
   const menu = $('#menu');
   const btnCollapse = menu.find('a.btn-expand-collapse');
 
+  function setCookie(name, value, days=365) {
+    var expires = "";
+    if (days) {
+      var date = new Date();
+      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = name + "=" + (value || "") + expires + "; path=/";
+  }
+
+  function getCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+  }
+
   const collapseLeftNav = () => {
-    // Toggle collapsed state of left-nav menu.
-    menu.toggleClass('collapsed');
     // Hide right chevrons of left-nav menu items.
     menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
     // Toggle the chevron in the collapse button right/left or left/right.
@@ -152,29 +171,31 @@ $(function() {
     menu.find('a.list-group-item').each((index, e) => {
       $(e).attr('title', menu.hasClass('collapsed') ? $(e).text() : '');
     });
-    // Expand width of the page when left-nav is collapsed.
-    $('.container').toggleClass('w-100');
   };
 
   const onCollapseLeftNav = () => {
+    // Toggle collapsed state of left-nav menu.
+    menu.toggleClass('collapsed');
     // Event handler for clicking left-nav collapse button.
     collapseLeftNav();
-    // Save settings.
-    localStorage[leftNavCollapseKey] = !JSON.parse(localStorage[leftNavCollapseKey] || '""');
+    // Expand width of the page when left-nav is collapsed.
+    $('.container').toggleClass('w-100');
+    // Save settings, use a cookie for smooth rendering of page upon load from server.
+    const isCollapse = getCookie('leftNavCollapse') || false;
+    setCookie('leftNavCollapse', !isCollapse);
   };
 
   const initializeLeftNav = () => {
     // Initialize left-nav menu state.
-    JSON.parse(localStorage[leftNavCollapseKey] || '""') && collapseLeftNav();
+    const isCollapse = getCookie('leftNavCollapse');
+    isCollapse && collapseLeftNav();
 
     // Setup event handler on left-nav collapse button click.
     btnCollapse.click(onCollapseLeftNav);
 
     // Enable animation effort on left-nav collapse.
-    setTimeout(() => {
-      menu.addClass('animated');
-      $('.container').addClass('animated');
-    }, 1);
+    menu.addClass('animated');
+    $('.container').addClass('animated');
   };
 
   initializeLeftNav();

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -135,71 +135,7 @@
 <ul class="list-group" style="margin-top: 21px;">
     {{ render_project_thumbnail(project, upload_method, class="img-responsive thumbnail card") }}
 </ul>
-<script>
-$(function() {
-  const leftNavCollapseKey = 'leftNavCollapse';
-  const menu = $('#menu');
-  const btnCollapse = menu.find('a.btn-expand-collapse');
-
-  function setCookie(name, value, days=365) {
-    var expires = "";
-    if (days) {
-      var date = new Date();
-      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-      expires = "; expires=" + date.toUTCString();
-    }
-    document.cookie = name + "=" + (value || "") + expires + "; path=/";
-  }
-
-  function getCookie(name) {
-    var nameEQ = name + "=";
-    var ca = document.cookie.split(';');
-    for (var i = 0; i < ca.length; i++) {
-      var c = ca[i];
-      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
-    }
-    return null;
-  }
-
-  const leftNavTooltips = () => {
-    // Set the tooltip to show the menu item text.
-    menu.find('a.list-group-item').each((index, e) => {
-      $(e).attr('title', menu.hasClass('collapsed') ? $(e).text() : '');
-    });
-  };
-
-  const onCollapseLeftNav = () => {
-    // Toggle collapsed state of left-nav menu.
-    menu.toggleClass('collapsed');
-    // Hide right chevrons of left-nav menu items.
-    menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
-    // Toggle the chevron in the collapse button right/left or left/right.
-    btnCollapse.find('i').toggleClass('fa-chevron-left fa-chevron-right');
-    // Set tooltips on left-nav menu.
-    leftNavTooltips();
-    // Expand width of the page when left-nav is collapsed.
-    $('.container').toggleClass('w-100');
-    // Save settings, use a cookie for smooth rendering of page upon load from server.
-    const isCollapse = getCookie('leftNavCollapse') || false;
-    setCookie('leftNavCollapse', !isCollapse);
-  };
-
-  const initializeLeftNav = () => {
-    // Initialize left-nav menu state.
-    const isCollapse = getCookie('leftNavCollapse');
-    isCollapse && leftNavTooltips();
-
-    // Setup event handler on left-nav collapse button click.
-    btnCollapse.click(onCollapseLeftNav);
-
-    // Enable animation effort on left-nav collapse.
-    $('.container').addClass('animated');
-  };
-
-  initializeLeftNav();
-});
-</script>
+<script src='/static/js/nav.js'></script>
 {% endmacro %}
 
 {% macro render_project_summary(project, n_tasks, overall_progress, last_activity, current_user, upload_method) -%}

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -103,9 +103,11 @@
 <script>
 $(function() {
   $('.btn-expand-collapse').click(function() {
-    $('#menu').toggleClass('collapsed');
-    $('#menu a.btn-expand-collapse i').toggleClass('fa-chevron-left fa-chevron-right');
-    $('#menu a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
+    const menu = $('#menu');
+
+    menu.toggleClass('collapsed');
+    menu.find('a.btn-expand-collapse i').toggleClass('fa-chevron-left fa-chevron-right');
+    menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
     $('.container').toggleClass('w-100');
   });
 });

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -106,6 +106,7 @@ $(function() {
     $('#menu').toggleClass('collapsed');
     $('#menu a.btn-expand-collapse i').toggleClass('fa-chevron-left fa-chevron-right');
     $('#menu a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
+    $('.container').toggleClass('w-100');
   });
 });
 </script>

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -148,6 +148,10 @@ $(function() {
     menu.find('a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
     // Toggle the chevron in the collapse button right/left or left/right.
     btnCollapse.find('i').toggleClass('fa-chevron-left fa-chevron-right');
+    // Set the tooltip to show the menu item text.
+    menu.find('a.list-group-item').each((index, e) => {
+      $(e).attr('title', menu.hasClass('collapsed') ? $(e).text() : '');
+    });
     // Expand width of the page when left-nav is collapsed.
     $('.container').toggleClass('w-100');
   };

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -41,30 +41,74 @@
     {% set is_subadmin_or_admin = current_user.subadmin or current_user.admin %}
 
     {% if is_admin_or_subadmin_or_owner %}
-        <a class="list-group-item {% if active_link=='info'%}active{% endif %}" href="{{url_for('project.details', short_name=project.short_name)}}">{{_('Info')}}<i class="fa fa-chevron-right pull-right"></i></a>
-        <a class="list-group-item {% if active_link=='tasks'%}active{% endif %}" href="{{url_for('project.tasks', short_name=project.short_name)}}">{{_('Tasks')}} {{daniel}}{% if task_subsection_1_text %}<a href="{{task_subsection_1}}">{{task_subsection_1_text}}</a>{% endif %}<i class="fa fa-chevron-right pull-right"></i></a>
+        <a class="list-group-item {% if active_link=='info'%}active{% endif %}" href="{{url_for('project.details', short_name=project.short_name)}}">
+            <i class='nav-icon fa fa-info-circle'></i>
+            <span class='nav-label'>{{_('Info')}}</span>
+            <i class="fa fa-chevron-right pull-right"></i>
+        </a>
+
+        <a class="list-group-item {% if active_link=='tasks'%}active{% endif %}" href="{{url_for('project.tasks', short_name=project.short_name)}}">
+            <i class='nav-icon fa fa-tasks'></i>
+            <span class='nav-label'>
+                {{_('Tasks')}} {{daniel}}{% if task_subsection_1_text %}<a href="{{task_subsection_1}}">{{task_subsection_1_text}}</a>{% endif %}
+            </span>
+            <i class="fa fa-chevron-right pull-right"></i>
+        </a>
     {% endif %}
 
     {% if is_subadmin_and_owner_or_admin %}
-        <a class="list-group-item {% if active_link=='settings'%}active{% endif %}" href="{{url_for('project.settings', short_name=project.short_name)}}">{{_('Project Settings')}}<i class="fa fa-chevron-right pull-right"></i></a>
+        <a class="list-group-item {% if active_link=='settings'%}active{% endif %}" href="{{url_for('project.settings', short_name=project.short_name)}}">
+            <i class='nav-icon fa fa-cog'></i>
+            <span class='nav-label'>{{_('Project Settings')}}</span>
+            <i class="fa fa-chevron-right pull-right"></i>
+        </a>
     {% endif %}
 
     {% if is_admin_or_subadmin_or_owner %}
-        <a class="list-group-item {% if active_link=='stats'%}active{% endif %}" href="{{url_for('project.show_stats', short_name=project.short_name)}}">{{_('Statistics')}}<i class="fa fa-chevron-right pull-right"></i></a>
+        <a class="list-group-item {% if active_link=='stats'%}active{% endif %}" href="{{url_for('project.show_stats', short_name=project.short_name)}}">
+            <i class='nav-icon fa fa-signal'></i>
+            <span class='nav-label'>{{_('Statistics')}}</span>
+            <i class="fa fa-chevron-right pull-right"></i>
+        </a>
     {% endif %}
-    <a class="list-group-item {% if active_link=='performancestats'%}active{% endif %}" href="{{url_for('project.show_performance_stats', short_name=project.short_name)}}">{{_('Performance Stats')}}<i class="fa fa-chevron-right pull-right"></i></a>
+    <a class="list-group-item {% if active_link=='performancestats'%}active{% endif %}" href="{{url_for('project.show_performance_stats', short_name=project.short_name)}}">
+        <i class='nav-icon fa fa-star'></i>
+        <span class='nav-label'>{{_('Performance Stats')}}</span>
+        <i class="fa fa-chevron-right pull-right"></i>
+    </a>
 
     {% if is_subadmin_and_owner_or_admin %}
-        <a class="list-group-item {% if active_link=='auditlog'%}active{% endif %}" href="{{url_for('project.auditlog', short_name=project.short_name)}}">{{_('Audit Logs')}}<i class="fa fa-chevron-right pull-right"></i></a>
+        <a class="list-group-item {% if active_link=='auditlog'%}active{% endif %}" href="{{url_for('project.auditlog', short_name=project.short_name)}}">
+            <i class='nav-icon fa fa-file'></i>
+            <span class='nav-label'>{{_('Audit Logs')}}</span>
+            <i class="fa fa-chevron-right pull-right"></i>
+        </a>
     {% endif %}
 
     {% if is_subadmin_or_admin %}
-        <a class="list-group-item {% if active_link=='clone'%}active{% endif %}" href="{{url_for('project.clone', short_name=project.short_name)}}">{{_('Clone')}}<i class="fa fa-chevron-right pull-right"></i></a>
+        <a class="list-group-item {% if active_link=='clone'%}active{% endif %}" href="{{url_for('project.clone', short_name=project.short_name)}}">
+            <i class='nav-icon fa fa-clone'></i>
+            <span class='nav-label'>{{_('Clone')}}</span>
+            <i class="fa fa-chevron-right pull-right"></i>
+        </a>
     {% endif %}
+
+    <a class="list-group-item btn-expand-collapse" href="#">
+        <i class="fa fa-chevron-left"></i>
+    </a>
 </div>
 <ul class="list-group" style="margin-top: 21px;">
     {{ render_project_thumbnail(project, upload_method, class="img-responsive thumbnail card") }}
 </ul>
+<script>
+$(function() {
+  $('.btn-expand-collapse').click(function() {
+    $('#menu').toggleClass('collapsed');
+    $('#menu a.btn-expand-collapse i').toggleClass('fa-chevron-left fa-chevron-right');
+    $('#menu a.list-group-item i.pull-right').toggleClass('fa fa-chevron-right');
+  });
+});
+</script>
 {% endmacro %}
 
 {% macro render_project_summary(project, n_tasks, overall_progress, last_activity, current_user, upload_method) -%}

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -194,7 +194,6 @@ $(function() {
     btnCollapse.click(onCollapseLeftNav);
 
     // Enable animation effort on left-nav collapse.
-    menu.addClass('animated');
     $('.container').addClass('animated');
   };
 

--- a/templates/projects/base.html
+++ b/templates/projects/base.html
@@ -6,13 +6,25 @@
 
 {% block content %}
 <div id="wizard-container">
+    {% if request.cookies.leftNavCollapse == "true" %}
+    <div class="container navigation-element w-100">
+    {% else %}
     <div class="container navigation-element">
-        {% include "projects/wizard.html" %}
+    {% endif %}
+    {% include "projects/wizard.html" %}
     </div>
 </div>
+{% if request.cookies.leftNavCollapse == "true" %}
+<div id="main-container" class="container w-100">
+{% else %}
 <div id="main-container" class="container">
+{% endif %}
     {% if project %}
+    {% if request.cookies.leftNavCollapse == "true" %}
+    <div id="menu" class="col-sm-3 col-md-3 navigation-element collapsed">
+    {% else %}
     <div id="menu" class="col-sm-3 col-md-3 navigation-element">
+    {% endif %}
         {{ helper.render_project_local_nav(project, active_link, current_user, pro_features, upload_method) }}
     </div>
     <!-- Project -->

--- a/templates/projects/base.html
+++ b/templates/projects/base.html
@@ -12,11 +12,7 @@
 </div>
 <div id="main-container" class="container {{'w-100' if request.cookies.leftNavCollapse == 'true'}}">
     {% if project %}
-    {% if request.cookies.leftNavCollapse == "true" %}
-    <div id="menu" class="col-sm-3 col-md-3 navigation-element collapsed">
-    {% else %}
-    <div id="menu" class="col-sm-3 col-md-3 navigation-element">
-    {% endif %}
+    <div id="menu" class="col-sm-3 col-md-3 navigation-element animated {{'collapsed' if request.cookies.leftNavCollapse == 'true'}}">
         {{ helper.render_project_local_nav(project, active_link, current_user, pro_features, upload_method) }}
     </div>
     <!-- Project -->

--- a/templates/projects/base.html
+++ b/templates/projects/base.html
@@ -6,19 +6,11 @@
 
 {% block content %}
 <div id="wizard-container">
-    {% if request.cookies.leftNavCollapse == "true" %}
-    <div class="container navigation-element w-100">
-    {% else %}
-    <div class="container navigation-element">
-    {% endif %}
+    <div class="container navigation-element {{'w-100' if request.cookies.leftNavCollapse == 'true'}}">
     {% include "projects/wizard.html" %}
     </div>
 </div>
-{% if request.cookies.leftNavCollapse == "true" %}
-<div id="main-container" class="container w-100">
-{% else %}
-<div id="main-container" class="container">
-{% endif %}
+<div id="main-container" class="container {{'w-100' if request.cookies.leftNavCollapse == 'true'}}">
     {% if project %}
     {% if request.cookies.leftNavCollapse == "true" %}
     <div id="menu" class="col-sm-3 col-md-3 navigation-element collapsed">

--- a/templates/projects/tasks_browse.html
+++ b/templates/projects/tasks_browse.html
@@ -36,8 +36,7 @@
     </div>
 </div>
 <div id="tasksBrowseControls">
-    <b> {{ _('Displaying') }} {{ pagination.curr_page_count }} {{ _(' of') }} {{ pagination.total_count }} </b>
-    <ul>
+    <ul class="pull-left">
         <li>
             <button class="btn btn-sm" id='btnRefresh' type="button" data-toggle="popover" data-trigger="focus" data-placement="top" data-constraints='focus' data-content="{{_('Please refresh the results after setting the desired filters.')}}" title="{{_('Search')}}">
                 <i class="fa fa-search" aria-hidden="true"></i>
@@ -125,19 +124,25 @@
         </li>
         {% endif %}
     </ul>
+    <div style="clear: both;"></div>
+    <div class="task-pagination">
+        Displaying tasks {{ ((pagination.page - 1) * pagination.per_page) + 1 }}-{{ ((pagination.page) * pagination.per_page) }} of {{ pagination.total_count }}
+    </div>
 </div>
 <div>
-    <table width="100%" id="tasksGrid">
+    <table id="tasksGrid" class="table table-sm table-striped table-hover">
         <thead>
             <tr>
                 {% if 'task_id' in filter_data.display_columns %}
-                <th class="{{'sort-asc' if filter_data.order_by['task_id'] == 'asc'}} {{'sort-desc' if filter_data.order_by['task_id'] == 'desc'}} sortable" data-sort="task_id">Task#</th>
+                <th class="{{'sort-asc' if filter_data.order_by['task_id'] == 'asc'}} {{'sort-desc' if filter_data.order_by['task_id'] == 'desc'}} sortable" data-sort="task_id">
+                    Task #
+                </th>
                 {% endif %}
                 {% if 'priority' in filter_data.display_columns %}
                 <th class="{{'sort-asc' if filter_data.order_by['priority'] == 'asc'}} {{'sort-desc' if filter_data.order_by['priority'] == 'desc'}} sortable" data-sort="priority">Priority</th>
                 {% endif %}
                 {% if 'pcomplete' in filter_data.display_columns %}
-                <th class="{{'sort-asc' if filter_data.order_by['pcomplete'] == 'asc'}} {{'sort-desc' if filter_data.order_by['pcomplete'] == 'desc'}} sortable" data-sort="pcomplete">%Complete</th>
+                <th class="{{'sort-asc' if filter_data.order_by['pcomplete'] == 'asc'}} {{'sort-desc' if filter_data.order_by['pcomplete'] == 'desc'}} sortable" data-sort="pcomplete">% Complete</th>
                 {% endif %}
                 {% if 'created' in filter_data.display_columns %}
                 <th class="{{'sort-asc' if filter_data.order_by['created'] == 'asc'}} {{'sort-desc' if filter_data.order_by['created'] == 'desc'}} sortable" data-sort="created">Created</th>
@@ -182,12 +187,12 @@
                 {% endif %}
                 {% if 'created' in filter_data.display_columns %}
                 <th>
-                   <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#dateModal" data-info="created">Select date range</button>
+                   <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#dateModal" data-info="created">Filter</button>
                 </th>
                 {% endif %}
                 {% if 'finish_time' in filter_data.display_columns %}
                 <th>
-                   <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#dateModal" data-info="ftime">Select date range</button>
+                   <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#dateModal" data-info="ftime">Filter</button>
                 </th>
                 {% endif %}
                 {% if 'gold_task' in filter_data.display_columns %}
@@ -244,34 +249,38 @@
                     {% endif %}
                 {% endif %}
                 {% if 'created' in filter_data.display_columns %}
-                <td>{{ t.created }}</td>
+                <td><div style="width: 100px;">{{ t.created }}</div></td>
                 {% endif %}
                 {% if 'finish_time' in filter_data.display_columns %}
-                <td>{{ t.finish_time or '' }}</td>
+                <td><div style="width: 100px;">{{ t.finish_time or '' }}</div></td>
                 {% endif %}
                 {% if 'gold_task' in filter_data.display_columns %}
                     {% if t.calibration %}
-                        <td style="width: 100%">
-                            <!-- Allow project owner, sub-admin co-owners, and admins to update Gold tasks -->
-                            {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
-                                <a class="gold-task label label-warning" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id, mode='gold') }}">Update</a>
-                            {% else %}
-                                <div class="gold-task label label-default" title="Only Project owners can update Gold tasks.">Update</div>
-                            {% endif %}
+                        <td>
+                            <div class="make-gold-cell">
+                                <!-- Allow project owner, sub-admin co-owners, and admins to update Gold tasks -->
+                                {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
+                                    <a class="gold-task label label-warning" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id, mode='gold') }}">Update</a>
+                                {% else %}
+                                    <div class="gold-task label label-default" title="Only Project owners can update Gold tasks.">Update</div>
+                                {% endif %}
+                            </div>
                         </td>
                     {% else %}
-                    <td style="width: 100%">
-                        <!-- Allow project owner, sub-admin co-owners, and admins to make Gold tasks -->
-                        {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
-                            <a class="gold-task label label-info" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id, mode='gold') }}">Make Gold</a>
-                        {% else %}
-                            <div class="gold-task label label-default" title="Only project owners can make Gold tasks.">Make Gold</div>
-                        {% endif %}
+                    <td>
+                        <div class="make-gold-cell">
+                            <!-- Allow project owner, sub-admin co-owners, and admins to make Gold tasks -->
+                            {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
+                                <a class="gold-task label label-info" target="_blank" href="{{ url_for('project.task_presenter', short_name=project.short_name, task_id=t.id, mode='gold') }}">Make Gold</a>
+                            {% else %}
+                                <div class="gold-task label label-default" title="Only project owners can make Gold tasks.">Make Gold</div>
+                            {% endif %}
+                        </div>
                     </td>
                     {% endif %}
                 {% endif %}
                 {% if 'actions' in filter_data.display_columns %}
-                <td style="width: 100px;">
+                <td>
                     <div style="width: 100px;">
                       {% if task_pct >= 100 %}
                       <a id="fulldownload" rel="nofollow" class="btn btn-success btn-xs fa fa-cloud-download" href="{{ url_for('project.export', short_name=project.short_name, task_id=t.id) }}">&nbsp;</a> <button type="button" class="btn btn-success btn-xs fa fa-eye" data-toggle="modal" data-target="#infoModal" data-info="{{ url_for('project.export', short_name=project.short_name, task_id=t.id) }}"></button>
@@ -589,7 +598,7 @@
 </div>
 </div>
 
-<script src="/static/js/gen/task_browse.min.820acb70bf41a77a9f75.js"></script>
+<script src="/static/js/gen/task_browse.min.6d48bd77b9235ca8bf3a.js"></script>
 <script type="text/javascript">
     var filter_data = {{ filter_data|tojson }};
     taskBrowse.setFilters(filter_data);

--- a/templates/projects/tasks_browse.html
+++ b/templates/projects/tasks_browse.html
@@ -126,7 +126,9 @@
     </ul>
     <div style="clear: both;"></div>
     <div class="task-pagination">
-        Displaying tasks {{ ((pagination.page - 1) * pagination.per_page) + 1 }}-{{ ((pagination.page) * pagination.per_page) }} of {{ pagination.total_count }}
+        <div>
+            Displaying tasks {{ ((pagination.page - 1) * pagination.per_page) + 1 }}-{{ ((pagination.page) * pagination.per_page) }} of {{ pagination.total_count }}
+        </div>
     </div>
 </div>
 <div>


### PR DESCRIPTION
- Left-nav icons.
- Left-nav collapse bar.
- Left-nav alignment.
- Task browse table filters bar alignment.
- Added "Displaying tasks 1-10 of 20" for pagination.
- Task browse table column width adjustment.
- Expanded page width when left-nav is collapsed.
- Task browse table hover effect on rows.
- Task browse table striped rows.
- Persistence for left-nav collapse state via cookie, supports smooth client and server-side rendering upon page load.

## Screenshots

### Animated Demo
![4-demo](https://user-images.githubusercontent.com/50708624/125352912-dc10f900-e32f-11eb-8d82-ee40237c9b58.gif)

### Left-nav Expanded

![2-expanded](https://user-images.githubusercontent.com/50708624/125352919-df0be980-e32f-11eb-9282-21d5da6cc150.png)

### Left-nav Collapsed

![3-collapsed](https://user-images.githubusercontent.com/50708624/125352920-df0be980-e32f-11eb-9637-d78570368752.png)

### Original

![1-old](https://user-images.githubusercontent.com/50708624/125352916-de735300-e32f-11eb-8b7d-8b073ef551ca.png)
