### PR TITLE
RDISCROWD-4747 Allow toggle between browse tasks and task list views.

### DIFF
--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -291,6 +291,17 @@
 </div>
 {% endmacro %}
 
+{% macro render_task_queue_toggle_buttons(project, current_user, view) %}
+    {% set is_admin_or_subadmin_or_owner = current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
+    <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}{{'' if (not is_admin_or_subadmin_or_owner or view == 'tasklist') else '?view=tasklist'}}">
+        {% if is_admin_or_subadmin_or_owner and view == 'tasklist' %}
+            Browse Tasks
+        {% else %}
+            Task List
+        {% endif %}
+    </a>
+{% endmacro %}
+
 {% macro render_contribute_button(project, current_user, csrf_token) %}
     {% if project['contrib_button'] == 'completed' %}
     <a href="{{url_for('project.tasks', short_name=project.short_name)}}" class="btn btn-lg btn-primary btn-contribute pull-right">{{ _('Done! View results') }}</a>
@@ -306,14 +317,7 @@
         <a href="{{ url_for('project.presenter', short_name=project.short_name)}}" class="btn btn-lg btn-primary btn-padding">{{ _('Start Contributing Now!') }}</a>
         {% endif %}
         {% if project['enable_task_queue'] %}
-            {% set is_admin_or_subadmin_or_owner = current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
-            <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}{{'' if (not is_admin_or_subadmin_or_owner or request.args['view'] == 'tasklist') else '?view=tasklist'}}">
-                {% if is_admin_or_subadmin_or_owner and request.args['view'] == 'tasklist' %}
-                    Browse Tasks
-                {% else %}
-                    Task List
-                {% endif %}
-            </a>
+            {{ render_task_queue_toggle_buttons(project, current_user, request.args['view']) }}
         {% endif %}
     </div>
     {% endif %}
@@ -329,16 +333,9 @@
         <a class="btn btn-lg btn-warning btn-padding" role="button" href="{{url_for('project.make_random_task_gold', short_name=project.short_name)}}">{{ _('Create Gold Questions!') }}</a>
         <a href="{{url_for('project.publish', short_name=project.short_name, published=1)}}" class="btn btn-lg btn-default">{{ _('Publish it') }}</a>
     </div>
-        {% if project['enable_task_queue'] %}
-            {% set is_admin_or_subadmin_or_owner = current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
-            <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}{{'' if (not is_admin_or_subadmin_or_owner or request.args['view'] == 'tasklist') else '?view=tasklist'}}">
-                {% if is_admin_or_subadmin_or_owner and request.args['view'] == 'tasklist' %}
-                    Browse Tasks
-                {% else %}
-                    Task List
-                {% endif %}
-            </a>
-        {% endif %}
+    {% if project['enable_task_queue'] %}
+        {{ render_task_queue_toggle_buttons(project, current_user, request.args['view']) }}
+    {% endif %}
     {% endif %}
 {% endmacro %}
 

--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -306,7 +306,14 @@
         <a href="{{ url_for('project.presenter', short_name=project.short_name)}}" class="btn btn-lg btn-primary btn-padding">{{ _('Start Contributing Now!') }}</a>
         {% endif %}
         {% if project['enable_task_queue'] %}
-    <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}">{{ _('Task List') }}</a>
+            {% set is_admin_or_subadmin_or_owner = current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
+            <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}{{'' if (not is_admin_or_subadmin_or_owner or request.args['view'] == 'tasklist') else '?view=tasklist'}}">
+                {% if is_admin_or_subadmin_or_owner and request.args['view'] == 'tasklist' %}
+                    Browse Tasks
+                {% else %}
+                    Task List
+                {% endif %}
+            </a>
         {% endif %}
     </div>
     {% endif %}
@@ -323,7 +330,14 @@
         <a href="{{url_for('project.publish', short_name=project.short_name, published=1)}}" class="btn btn-lg btn-default">{{ _('Publish it') }}</a>
     </div>
         {% if project['enable_task_queue'] %}
-            <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}">{{ _('Task List') }}</a>
+            {% set is_admin_or_subadmin_or_owner = current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
+            <a class="btn btn-lg btn-primary btn-padding" role="button" href="{{url_for('project.tasks_browse', short_name=project.short_name)}}{{'' if (not is_admin_or_subadmin_or_owner or request.args['view'] == 'tasklist') else '?view=tasklist'}}">
+                {% if is_admin_or_subadmin_or_owner and request.args['view'] == 'tasklist' %}
+                    Browse Tasks
+                {% else %}
+                    Task List
+                {% endif %}
+            </a>
         {% endif %}
     {% endif %}
 {% endmacro %}

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -45,7 +45,7 @@
                 <i class="fa fa-search" aria-hidden="true"></i>
             </button>
         </li>
-        {% if  current_user.id in project.owners_ids or current_user.subadmin or current_user.admin %}
+        {% if (current_user.id in project.owners_ids or current_user.subadmin or current_user.admin) and request.args['view'] != 'tasklist' %}
           <li class="dropdown">
               <button class="dropdown-toggle btn btn-sm" type="button" id="btnDownload" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" title="Export tasks/task runs"><span class="fa fa-cloud-download"></span><span class="caret"></span></button>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu4">
@@ -70,7 +70,7 @@
                 {% endfor %}
             </ul>
         </li>
-        {% if current_user.id in project.owners_ids or current_user.subadmin or current_user.admin %}
+        {% if (current_user.id in project.owners_ids or current_user.subadmin or current_user.admin) and request.args['view'] != 'tasklist' %}
           <li class="dropdown" id="columnsSettings">
               <button class="dropdown-toggle btn btn-sm" type="button" id="btnColumnsSettings" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" title="Columns"><span class="fa fa-cog"><span class="caret"></span></button>
               <ul class="dropdown-menu" aria-labelledby="btnColumnsSettings">
@@ -105,7 +105,7 @@
           </li>
         {% endif %}
         <!-- Project owner, subadmin that are project co-owners and admins can edit/delete task properties -->
-        {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
+        {% if ((current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin) and request.args['view'] != 'tasklist' %}
         <li class="dropdown" id="edit-tasks">
             <button class="dropdown-toggle btn btn-sm" type="button" id="btn-edit-tasks" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" title="Edit priority/redundancy"><span class="fa fa-edit"><span class="caret"></span></button>
             <ul class="dropdown-menu" aria-labelledby="btn-edit-tasks">
@@ -119,7 +119,7 @@
             </button>
         </li>
         {% endif %}
-        {% if language_options and (current_user.id in project.owners_ids or current_user.subadmin or current_user.admin) %}
+        {% if language_options and request.args['view'] != 'tasklist' and (current_user.id in project.owners_ids or current_user.subadmin or current_user.admin) %}
         <li>
             <button id="btn-filter-user-pref" class="btn btn-sm" type="button" data-target="#filter-upref-modal" data-toggle="modal" title="Filter by user preference">
                 <i class="fa fa-user" aria-hidden="true"></i>

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -643,7 +643,8 @@
     const proj = {{ project |tojson }};
     const userId = {{ current_user.id |trim}}
     const adminPriv = {{ current_user.admin |tojson }} || {{ current_user.subadmin |tojson }}
-    const enableAutoRefresh = (proj['enable_task_queue'] && !adminPriv && !(userId in proj["owners_ids"]))
+    const viewType = '{{ request.args.get('view') }}'
+    const enableAutoRefresh = (proj['enable_task_queue'] && (viewType === 'tasklist' || (!adminPriv && !(userId in proj["owners_ids"]))))
     const refreshInterval = 60000;
     let refresh = null;
 

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -16,7 +16,7 @@
 <div class="row">
     <div class="col-md-12">
         <p>{{_('This page shows all the available tasks for this project')}}.</p>
-        {% if current_user.id in project.owners_ids or current_user.subadmin or current_user.admin %}
+        {% if (current_user.id in project.owners_ids or current_user.subadmin or current_user.admin) and request.args['view'] != 'tasklist' %}
           <p>{{_('For each task, you can find the following information')}}:
           <ul>
               <li><strong>{{_('Task')}} </strong><span class="label label-info">#0000</span> {{_('This number identifies the task for the project and it is unique')}}</li>


### PR DESCRIPTION
- Allow toggle between browse tasks and task list views.
- Task list view for admins/owners displays the same view as a worker would see (including hidden instructions panel and limited buttons _[Filters, page, search]_)

## Screenshot

![tasklist-browse-2](https://user-images.githubusercontent.com/50708624/140784831-ac81a152-573a-4b4a-b215-a661bb5d6aef.gif)

Re: https://github.com/bloomberg/pybossa/pull/638