### PR TITLE
downgrade d3 to 3.5.15 to resolve import issue

### DIFF
--- a/static/src/package.json
+++ b/static/src/package.json
@@ -42,7 +42,7 @@
     "cropperjs": "^1.0.0-rc.2",
     "cross-spawn": "^2.1.5",
     "css-loader": "^0.23.0",
-    "d3": "~3.5.17",
+    "d3": "3.5.15",
     "eslint": "5.15.3",
     "eslint-config-prettier": "4.1.0",
     "eslint-config-standard": "12.0.0",


### PR DESCRIPTION
*Issue number of the reported bug or feature request: NULL*

**Describe your changes**
Downgrade d3 build to use the exact version 3.5.15

**Testing performed**
Tested locally

**Additional context**
The current approximate version ~3.5.17 uses 3.5.17, which causes import error for ```import * as d3 from 'd3'```
