### PR TITLE
RDISCROWD-4878 Task browse bulk edit state not updating - UI

### DIFF
--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -647,9 +647,11 @@
 {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
 <div id="context-menu" class="dropdown clearfix">
     <ul class="dropdown-menu" role="menu" aria-labelledby="dropdown-menu" style="display:block;position:absolute;">
+        {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
         <li><a href="#" id="edit-pri" data-value="task-priority">Edit Priority</a></li>
         <li><a href="#" id="edit-red" data-value="task-redundancy">Edit Redundancy</a></li>
-        {% if project.info.sched == 'task_queue_scheduler' or project.info.sched == 'user_pref_scheduler'  %}
+        {% endif %}
+        {% if (current_user.id in project.owners_ids or current_user.admin) and (project.info.sched == 'task_queue_scheduler' or project.info.sched == 'user_pref_scheduler')  %}
         <li><a href="#" id="edit-user" data-value="assign-worker" @click="$refs.assignworker.getData()">Assign Worker </a></li>
         {% endif %}
         <li><a href="#" id="del-task" data-target="#delete-tasks-modal" data-toggle="modal">Delete Task</a></li>

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -644,7 +644,7 @@
 </div>
 
 <!-- Project owner, subadmin that are project co-owners and admins can edit/delete task properties -->
-{% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
+{% if current_user.id in project.owners_ids or current_user.admin %}
 <div id="context-menu" class="dropdown clearfix">
     <ul class="dropdown-menu" role="menu" aria-labelledby="dropdown-menu" style="display:block;position:absolute;">
         {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -650,11 +650,11 @@
         {% if (current_user.subadmin and current_user.id in project.owners_ids) or current_user.admin %}
         <li><a href="#" id="edit-pri" data-value="task-priority">Edit Priority</a></li>
         <li><a href="#" id="edit-red" data-value="task-redundancy">Edit Redundancy</a></li>
+        <li><a href="#" id="del-task" data-target="#delete-tasks-modal" data-toggle="modal">Delete Task</a></li>
         {% endif %}
         {% if (current_user.id in project.owners_ids or current_user.admin) and (project.info.sched == 'task_queue_scheduler' or project.info.sched == 'user_pref_scheduler')  %}
         <li><a href="#" id="edit-user" data-value="assign-worker" @click="$refs.assignworker.getData()">Assign Worker </a></li>
         {% endif %}
-        <li><a href="#" id="del-task" data-target="#delete-tasks-modal" data-toggle="modal">Delete Task</a></li>
     </ul>
 </div>
 {% endif %}


### PR DESCRIPTION
*Deliverables*:

1. The bulk edit options edit priority, edit redundancy, and task assignment should be applied to all tasks in the current filter - this includes the scenario when the modal for single task edit is open and closed without updating, followed by a bulk edit update. 
2. Bulk assign should skip gold tasks.
3. allow co-owners to be able to assign tickets even if they are not sub admin