### PR TITLE
RDISCROWD-5067 Style browse tasks table

### DIFF
--- a/static/css/task_browse.css
+++ b/static/css/task_browse.css
@@ -37,12 +37,47 @@
 }
 #tasksGrid thead tr:nth-child(2) th {
     background-color: #fafafa;
+    padding: 4px 4px 4px 4px;
+}
+#tasksGrid thead tr:nth-child(2) th div {
+    max-height: 26px;
+}
+#tasksGrid thead tr:nth-child(2) th input,
+#tasksGrid thead tr:nth-child(2) th button,
+#tasksGrid thead tr:nth-child(2) th .input-group-addon,
+#tasksGrid thead tr:nth-child(2) th .btn-sm,
+#tasksGrid thead tr:nth-child(2) th .slider-handle,
+#tasksGrid thead tr:nth-child(2) th select {
+    max-height: 26px;
+    padding: 4px 4px 4px 4px;
+}
+#tasksGrid thead tr:nth-child(2) th select {
+    padding: 0 0 0 4px;
+    width: 102px;
+}
+#tasksGrid thead tr:nth-child(2) th .btn-sm {
+    padding: 2px 10px 6px 10px;
+    width: 92px;
+}
+#tasksGrid .make-gold-cell a {
+    text-decoration: none;
+}
+#tasksGrid thead tr:nth-child(2) th .slider-handle {
+    max-height: 14px;
+    max-width: 14px;
+}
+#tasksGrid thead tr:nth-child(2) th .slider .tooltip.top {
+    top: -4px !important;
+    font-size: 12px;
 }
 #tasksGrid th, td {
     padding: 15px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+#tasksGrid th {
+    padding: 8px 4px 8px 4px;
 }
 #tasksGrid td {
     padding: 0 10px 0 5px;

--- a/static/css/task_browse.css
+++ b/static/css/task_browse.css
@@ -2,7 +2,6 @@
 #tasksGrid th.sort-asc:after{
     content: '';
     position: relative;
-    left: -20px;
     float: right;
     border: 7px solid transparent;
 }
@@ -13,11 +12,6 @@
 #tasksGrid th.sort-asc:after{
     border-bottom-color: silver;
 }
-#tasksGrid th.sort-desc,
-#tasksGrid th.sort-asc{
-    padding-left: 20px;
-}
-
 #tasksBrowseControls {
     padding-left:0;
 }
@@ -31,10 +25,33 @@
 }
 #tasksGrid th.sortable {
     cursor: pointer;
+    padding-left: 5px;
 }
 #tasksGrid .gold-task {
     display: block;
     margin: 0 0.25rem;
+}
+#tasksGrid th {
+    border-bottom: 1px solid #ccc;
+    background-color: #f0f0f0;
+}
+#tasksGrid thead tr:nth-child(2) th {
+    background-color: #fafafa;
+}
+#tasksGrid th, td {
+    padding: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+#tasksGrid td {
+    padding: 0 10px 0 5px;
+}
+#tasksGrid.border td, #tasksGrid.border th {
+    border-right: 1px solid #ccc;
+}
+#tasksGrid thead tr th:hover {
+    color: #3498db;
 }
 #date_from {
     z-index: 1051;

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -150,7 +150,7 @@
     </div>
 </div>
 <div>
-    <table id="tasksGrid" class="table table-sm table-striped table-hover">
+    <table id="tasksGrid" class="table table-sm table-striped table-hover border">
         <thead>
             <tr>
                 {% if 'task_id' in filter_data.display_columns %}

--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -233,7 +233,7 @@
                 {% if 'actions' in filter_data.display_columns %}
                 <th>&nbsp;</th>
                 {% endif %}
-                {% for column_name in info_column %}
+                {% for column_name in info_columns %}
                 <th>&nbsp;</th>
                 {% endfor %}
                 {% if 'lock_status' in filter_data.display_columns %}


### PR DESCRIPTION
- Added styling to browse tasks table.
- Added blue hover effect for column headers.
- Added column spacing.
- Added css class `border` for `#tasksGrid` table element to show/hide table cell borders.

## Screenshots

### Before and After

![before-after-anim](https://user-images.githubusercontent.com/50708624/161793553-fcea2105-b023-43ac-898e-e6e7881bad67.gif)

### Tighter Borders

![after-task-list-tighter](https://user-images.githubusercontent.com/50708624/162026014-e6933f0c-b3ef-4f66-8dcf-b642e624718b.png)

![after-browse-tasks-tighter](https://user-images.githubusercontent.com/50708624/162026017-e7aa5d84-abb8-4a40-9fd3-000fae1ca9da.png)

![after-browse-tasks-tighter-border](https://user-images.githubusercontent.com/50708624/162026011-b03b1ae5-d3ee-4060-a253-131d9dcc8c53.png)

![after-task-list-tighter-border](https://user-images.githubusercontent.com/50708624/162026013-199a40c3-55c3-46b4-bd87-e21cb3fa4e25.png)

