### PR TITLE
RDISCROWD-5117 Reload page on single column sort

### DIFF
--- a/static/js/tasks_browse.js
+++ b/static/js/tasks_browse.js
@@ -1,10 +1,10 @@
 ;(function(){
 var dateModalInfo = '';
 
-function dirtyView() {
+function dirtyView(showHint = true) {
     if (filter_data.changed === false) {
         filter_data.changed = true;
-        $('[data-toggle=popover]').popover('show');
+        showHint && $('[data-toggle=popover]').popover('show');
     }
 }
 
@@ -116,7 +116,7 @@ $(document).ready(function() {
     });
 
     $('#tasksGrid th[data-sort]').click(function(evt) {
-        dirtyView();
+        dirtyView(evt.ctrlKey);
 
         var column = $(this);
 

--- a/static/js/tasks_browse.js
+++ b/static/js/tasks_browse.js
@@ -130,6 +130,9 @@ $(document).ready(function() {
         else {
             $(this).toggleClass('sort-asc sort-desc');
         }
+
+        // If not selecting multiple columns, refresh the page with the single sort.
+        !evt.ctrlKey && refresh();
     });
 
     $('#infoModal').on('show.bs.modal', function(event) {


### PR DESCRIPTION
- Reload page on single column sort.

*Multiple columns may be selected by holding CTRL and clicking columns, followed by clicking the refresh icon.*

## Screenshots

### Sorting on multiple columns

![multisort](https://user-images.githubusercontent.com/50708624/166302454-6d06b3c4-ee4f-465f-945e-db081c3c9db1.png)

### Sorting on a single column

![singlesort](https://user-images.githubusercontent.com/50708624/166302457-911d24b6-ed87-400e-bd8d-450b41cce2f6.png)

