### PR TITLE
RDISCROWD-5117 Refresh page upon single column sort. User may still hold CTRL to sel…

### DIFF
--- a/static/js/tasks_browse.js
+++ b/static/js/tasks_browse.js
@@ -1,10 +1,10 @@
 ;(function(){
 var dateModalInfo = '';
 
-function dirtyView() {
+function dirtyView(showHint = true) {
     if (filter_data.changed === false) {
         filter_data.changed = true;
-        $('[data-toggle=popover]').popover('show');
+        showHint && $('[data-toggle=popover]').popover('show');
     }
 }
 
@@ -116,7 +116,7 @@ $(document).ready(function() {
     });
 
     $('#tasksGrid th[data-sort]').click(function(evt) {
-        dirtyView();
+        dirtyView(evt.ctrlKey);
 
         var column = $(this);
 
@@ -130,6 +130,9 @@ $(document).ready(function() {
         else {
             $(this).toggleClass('sort-asc sort-desc');
         }
+
+        // If not selecting multiple columns, refresh the page with the single sort.
+        !evt.ctrlKey && refresh();
     });
 
     $('#infoModal').on('show.bs.modal', function(event) {


### PR DESCRIPTION
 Reload page on single column sort.

*Multiple columns may be selected by holding CTRL and clicking columns, followed by clicking the refresh icon.*

## Screenshots

### Sorting on multiple columns

![multisort](https://user-images.githubusercontent.com/50708624/166305138-98970ff3-a864-4096-871e-e42463c4dc8d.png)

### Sorting on a single column

![singlesort](https://user-images.githubusercontent.com/50708624/166305166-f43129ad-7a4a-47be-8cfe-f884c0484331.png)
