### PR TITLE
RDISCROWD-5073: disable select2 autosort for task list columns selection.

### DIFF
--- a/templates/projects/task_scheduler.html
+++ b/templates/projects/task_scheduler.html
@@ -90,5 +90,15 @@
     function selectSchedulerNeedsCustomizedColumns() {
         return selectedScheduler() === 'task_queue_scheduler';
     }
+
+    $("#show-customized").on("select2:select", function(evt){
+        var element = evt.params.data.element;
+        var $element = $(element);
+        var parentElement = element.parentElement;
+
+        $element.detach();
+        $(parentElement).append($element);
+        $(parentElement).trigger("change");
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION
select2 auto sorts alphabetically the selected items thereby loosing track of the order of selection. There's no option provided by select2 that can disable autosort; [PR](https://github.com/select2/select2/pull/6014/files) on similar lines was closed in the past. Hence, solution was to implement jquery to trap selection event as described [here](https://stackoverflow.com/questions/31431197/select2-how-to-prevent-tags-sorting).