### PR TITLE
add codemirror 5.65.1

### DIFF
--- a/static/src/package.json
+++ b/static/src/package.json
@@ -37,6 +37,7 @@
     "babel-register": "^6.0.0",
     "babel-runtime": "^6.26.0",
     "chai": "^3.5.0",
+    "codemirror": "^5.65.1",
     "connect-history-api-fallback": "^1.1.0",
     "coveralls": "^3.0.2",
     "cropperjs": "^1.0.0-rc.2",


### PR DESCRIPTION
*Issue number of the reported bug or feature request: NULL*

**Describe your changes**
When running "yarn webpack" in Jenkins, it appears the following error:
ERROR in ./node_modules/simplemde/src/js/simplemde.js
2022-06-08 17:16:40 |  Module not found: Error: Can't resolve 'codemirror/addon/display/fullscreen.js' in '/build/pybossa/pybossa/themes/default/static/src/node_modules/simplemde/src/js

Could be related to codemirror version. So the change is to use a specific version.

**Testing performed**
tested locally.

