### PR TITLE
RDISCROWD-5407 Assign users dropdown menu

### DIFF
--- a/static/css/task_browse.css
+++ b/static/css/task_browse.css
@@ -145,3 +145,7 @@
 #tasksBrowseControls>ul>li:last-child {
     padding-left: 0;
 }
+
+#edit-tasks .dropdown-menu {
+    z-index: 1100;
+}


### PR DESCRIPTION
- CSS fix for assign users dropdown menu.

## Screenshots

### New

**Hovering the mouse over the bottom-right corner of the menu no longer activates the underlying slider control.**

![after](https://user-images.githubusercontent.com/50708624/186708255-993287c8-3058-46a7-a0e3-61edf9f6fbd5.png)

### Old

**Hovering the mouse over the bottom-right corner of the menu accidentally activates the underlying slider control.**

![cap](https://user-images.githubusercontent.com/50708624/186707801-f9cba411-98e3-4607-ade5-1247f2a53251.png)
