### PR TITLE
RDISCROWD-5481 Addition project info fields for workers

### DIFF
--- a/templates/projects/project.html
+++ b/templates/projects/project.html
@@ -17,7 +17,6 @@
                     <td><p>Total number of tasks:</p></td>
                     <td><p>{{n_tasks}}</p></td>
                 </tr>
-                {% if current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
                 <tr>
                     <td><p>Number of tasks in queue:</p></td>
                     <td><p>{{n_available_tasks}}</p></td>
@@ -30,6 +29,7 @@
                     <td><p>Number of tasks in progress:</p></td>
                     <td><p>{{num_locked_tasks}}</p></td>
                 </tr>
+                {% if current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
                 <tr>
                     <td><p>Total number of task runs:</p></td>
                     <td><p>{{num_expected_task_runs}}</p></td>


### PR DESCRIPTION
- Allow all users to view project info fields: Number of tasks in queue, Number of priority 1 tasks in queue, Number of tasks in progress

## Screenshots

### Worker View (Before)

![worker-before](https://user-images.githubusercontent.com/50708624/197022674-0752f1c9-5bed-434a-937c-0dbd823d4a56.png)

### Worker View (After)

![worker](https://user-images.githubusercontent.com/50708624/197022465-ec99f392-ec5b-4d19-90cf-27fc7406a98d.png)

### Project Owner View

![admin](https://user-images.githubusercontent.com/50708624/197022466-6a51d7d1-2869-4bdb-9642-814882c24bb8.png)
