### PR TITLE
RDISCROWD-5307 Disable image uploads in task guidelines

### DIFF
--- a/static/css/projects.css
+++ b/static/css/projects.css
@@ -1,3 +1,16 @@
 #btn-contribute-now.btn-contribute-now-unpublished>a.btn:last-child {
     margin-left: 2px;
 }
+
+.note-editor .modal-content {
+    padding: 12px;
+}
+
+.note-editor .modal-footer {
+    padding-bottom: 2px;
+    padding-right: 0;
+}
+
+.note-group-select-from-files {
+  display: none;
+}

--- a/templates/projects/project.html
+++ b/templates/projects/project.html
@@ -17,7 +17,6 @@
                     <td><p>Total number of tasks:</p></td>
                     <td><p>{{n_tasks}}</p></td>
                 </tr>
-                {% if current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
                 <tr>
                     <td><p>Number of tasks in queue:</p></td>
                     <td><p>{{n_available_tasks}}</p></td>
@@ -30,6 +29,7 @@
                     <td><p>Number of tasks in progress:</p></td>
                     <td><p>{{num_locked_tasks}}</p></td>
                 </tr>
+                {% if current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
                 <tr>
                     <td><p>Total number of task runs:</p></td>
                     <td><p>{{num_expected_task_runs}}</p></td>

--- a/templates/projects/project.html
+++ b/templates/projects/project.html
@@ -17,6 +17,7 @@
                     <td><p>Total number of tasks:</p></td>
                     <td><p>{{n_tasks}}</p></td>
                 </tr>
+                {% if current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
                 <tr>
                     <td><p>Number of tasks in queue:</p></td>
                     <td><p>{{n_available_tasks}}</p></td>
@@ -29,7 +30,6 @@
                     <td><p>Number of tasks in progress:</p></td>
                     <td><p>{{num_locked_tasks}}</p></td>
                 </tr>
-                {% if current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
                 <tr>
                     <td><p>Total number of task runs:</p></td>
                     <td><p>{{num_expected_task_runs}}</p></td>


### PR DESCRIPTION
- Disable image upload from task guidelines widget (keep ability to link images).
- Cleanup UI borders for modals.

## Screenshots

### After

Note, button for "Upload" is no longer displayed. Border spacing has been cleaned up.

![after-1](https://user-images.githubusercontent.com/50708624/203102138-ee4eea62-2627-441a-b95f-b2db20dc89fd.png)

![after-2](https://user-images.githubusercontent.com/50708624/203102137-7238c288-4bb1-4212-9c38-883b0b1da894.png)

### Before

Note, button for uploading files. Incorrect border spacing.

![before](https://user-images.githubusercontent.com/50708624/203102134-9fc7030c-53b2-49ae-8b44-f382f7b42339.png)

