### PR TITLE
RDISCROWD-5609 Redirect to project home on task completion

### DIFF
--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -59,5 +59,14 @@ $(function() {
     $('.container').addClass('animated');
   };
 
+  const notifyProjectComplete = () => {
+    // When the url parameter contains ?completed=true, show a notification.
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("completed") == "true") {
+      pybossaNotify('Congratulations, you have completed the job.', true, 'success', true);
+    }
+};
+
   initializeLeftNav();
+  notifyProjectComplete()
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,12 +70,6 @@
         window.cookieconsent_options = {"message":"Cookies help us to deliver our services. By using our services, you agree to our use of cookies.","dismiss":"Got it!","learnMore":"Learn More.","link":"{{url_for('help.cookies_policy')}}","theme":"dark-bottom"};
     </script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
-    <script>
-      const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.get("completed") == "true") {
-        pybossaNotify('Congratulations, you have completed the job.', true, 'success', true);
-      }
-    </script>
     {% block extrajs %}
     {% endblock %}
     {% include "_flash_messages.html" %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -72,11 +72,7 @@
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
     <script>
       const urlParams = new URLSearchParams(window.location.search);
-<<<<<<< HEAD
       if (urlParams.get("completed") == "true") {
-=======
-      if (urlParams.get("completed")) {
->>>>>>> 0c0cbea6b15661d6b7f69bf6eef15734f4bf2350
         pybossaNotify('Congratulations, you have completed the job.', true, 'success', true);
       }
     </script>


### PR DESCRIPTION
*Issue number of the reported bug or feature request: [RDISCROWD-5609](https://jira.prod.bloomberg.com/browse/RDISCROWD-5609)

**Describe your changes**
Previously: When the user finishes all tasks, they are left hanging looking at their last completed task. It's extra work for them to manually get to the project home page.
Now: When the user finishes all tasks, they are automatically redirected to the project home page.

**Testing performed**
Tested locally

**Additional PR**
https://github.com/bloomberg/pybossa.js/pull/17
