### PR TITLE
RDISCROWD-5654: fix title and update references with new variable

### DIFF
--- a/templates/projects/tasks_browse.webpack.ejs
+++ b/templates/projects/tasks_browse.webpack.ejs
@@ -2,10 +2,9 @@
 {% set active_page = "projects" %}
 {% set active_project  = "all" %}
 {% set active_link = "tasks" %}
-{% import "projects/_helpers.html" as project_helper %}
-
 {% set is_task_list = request.args['view'] == 'tasklist' %}
-{% set section = _('Task List') if is_task_list else 'Browse Tasks' %}
+{% set section = _('Task List') if is_task_list else _('Browse Tasks') %}
+{% import "projects/_helpers.html" as project_helper %}
 
 {% block projectcontent %}
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">


### PR DESCRIPTION
[RDISCROWD-5654](https://jira.prod.bloomberg.com/browse/RDISCROWD-5654): Fix Title on Browse Tasks / Task List Pages

**Describe your changes**
- added logic to change header based on task list/browse button
- created a variable to track the state of the button and updated references

**Testing performed**
Checked the changes by running GIGwork locally

Browse Task Header
![browse_task_header](https://user-images.githubusercontent.com/4377042/227310467-e09dabdb-c62c-49c5-a232-e493c31b51e6.png)

Task List Header
![task_list_header](https://user-images.githubusercontent.com/4377042/227310478-40bcd70a-c20b-4494-b79d-de99b988bf0a.png)

Re: https://github.com/bloomberg/pybossa/pull/831