### PR TITLE
RDISCROWD-5709 - Autosave duration default

### DIFF
--- a/static/src/components/builder/components/TaskPresenter/TaskPresenterForm.vue
+++ b/static/src/components/builder/components/TaskPresenter/TaskPresenterForm.vue
@@ -88,9 +88,7 @@
     },
     watch: {
       allowSaveWork: function (newValue) {
-        if (newValue !== true) {
-          this.autoSaveSeconds = 60;
-        }
+        this.autoSaveSeconds = newValue ? 60 : 0;
       }
     },
     updated () {

--- a/static/src/components/builder/store/modules/taskPresenter.js
+++ b/static/src/components/builder/store/modules/taskPresenter.js
@@ -4,7 +4,7 @@ import utils from '../../utils';
 const initialState = () => {
   return {
     allowSaveWork: false,
-    autoSaveSeconds: 60,
+    autoSaveSeconds: 0,
     allowAssignToUser: false
   };
 };


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-5709*

**Describe your changes**
In the Task Presenter component, `:auto-save-seconds` should reset to 0 when partial saving is disabled.

## Allow Partial work to be saved = true
![Screenshot 2023-07-19 at 12 43 15 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/618b1b78-aa66-4597-b4cc-2cc278a904ca)
![Screenshot 2023-07-19 at 12 43 22 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/4b4a0b71-0ee7-4a61-ba37-e4435180bc23)


## Allow Partial work to be saved = false
![Screenshot 2023-07-19 at 12 42 55 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/f1c76ab4-d723-47b6-8f02-1d0310189aaf)
![Screenshot 2023-07-19 at 12 43 09 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/1d067392-071d-465b-b96f-88852f41d2cd)
