### PR TITLE
RDISCROWD-6222 Show GIGwork users why no tasks are available

### DIFF
--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -293,6 +293,24 @@
 </div>
 {% endmacro %}
 
+{% macro render_project_incomplete_info_panel(info) %}
+<div class="panel panel-info">
+    <div class="panel-heading">
+        <h3 class="panel-title"><i class="fa fa-info-circle"></i> {{ _('You have no remaining tasks, but the project is not complete because:') }}</h3>
+    </div>
+    <div class="panel-body">
+        <ul>
+            {% if 'user_preferences' in info %}
+            {% set task_scheduler = info['user_preferences'].get('task_scheduler') %}
+            {% set account_profile_link =  info['user_preferences'].get('account_profile_link') %}
+            <li>{{ _('Your <a href="{}">user preferences</a> do not match the remaining task preferences as set by the project owner.').format(account_profile_link) }}</li>
+            <li>{{ _('The scheduler for this project is the {}.').format(task_scheduler) }}</li>
+            {% endif %}
+        </ul>
+    </div>
+</div>
+{% endmacro %}
+
 {% macro render_task_queue_toggle_buttons(project, current_user, view) %}
     {% set is_admin_or_subadmin_or_owner = current_user.admin or current_user.subadmin or current_user.id in project.owners_ids %}
     {% set regular_user = not is_admin_or_subadmin_or_owner %}

--- a/templates/projects/base.html
+++ b/templates/projects/base.html
@@ -33,6 +33,9 @@
                     <div>{{ overall_progress | round | int }}%</div>
                   </div>
                 </div>
+                {% if notifications is defined and 'project_incomplete_info' in notifications %}
+                    {{helper.render_project_incomplete_info_panel(notifications['project_incomplete_info'])}}
+                {% endif %}
             {% endif %}
             {% if active_link == 'info' and project.long_description != project.description %}
                 <div class="row">


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-6222*

**Describe your changes**
Show GIGwork users why no tasks are available

**Testing performed**
Because of null checks, template will not crash if variables are not present.




![Screenshot 2023-07-27 at 6 16 30 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/82f223a5-e23e-4984-9879-6fb33ec88fa8)

![Screenshot 2023-07-27 at 6 17 29 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/88e6b99a-ad90-42b3-86a9-59a69e20f6f7)

