### PR TITLE
RDISCROWD-5830 Rename NLP Enrichment to Span Annotation (NER)

### DIFF
--- a/static/src/components/builder/components/Questions.vue
+++ b/static/src/components/builder/components/Questions.vue
@@ -198,7 +198,7 @@ export default {
         name: 'TEXT_TAGGING_FORM',
         params: {
           componentName: 'TEXT_TAGGING',
-          header: 'NLP Enrichment'
+          header: 'Span Annotation (NER)'
         }
       },
       assistantLLM: {


### PR DESCRIPTION
- Renamed helper component "NLP Enrichment" to "Span Annotation (NER)".

## Screenshots

![cap3](https://github.com/bloomberg/pybossa-default-theme/assets/50708624/fcbd9f86-4f3a-4e54-9f64-997e52d64af2)

![cap4](https://github.com/bloomberg/pybossa-default-theme/assets/50708624/3f69130d-2bfc-4661-8f5b-143cac01b99d)
