### PR TITLE
RDISCROWD-6793 (4) hide empty helper component prop when empty

### DIFF
--- a/static/src/components/builder/components/Anco/AncoTemplate.html
+++ b/static/src/components/builder/components/Anco/AncoTemplate.html
@@ -2,7 +2,6 @@
   v-if='{{docUrl}}'
   pyb-answer='{{pybAnswer}}'
   :doc-url='{{docUrl}}'
-  :annotation-url='{{annotationUrl}}'
-  annotation-type='{{annotationType}}'
   categories='{{categories}}'
+  annotation-type='{{annotationType}}'{{{annotationUrl}}}
 ></anco-loader>

--- a/static/src/components/builder/utils.js
+++ b/static/src/components/builder/utils.js
@@ -423,11 +423,12 @@ export default {
       docUrl,
       annotationType: 'BoundingBox',
       requiredAnnotationOnLoad: !!annotationUrl,
-      categories: JSON.stringify(categories)
+      categories: JSON.stringify(categories),
+      annotationUrl: ''
     };
 
     if (annotationUrl) {
-      config.annotationUrl = annotationUrl;
+      config.annotationUrl = `\n  :annotation-url='${annotationUrl}'`;
     }
 
     const output = Mustache.render(ancoTemplate, {

--- a/static/src/package-lock.json
+++ b/static/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@dtwebservices/task-presenter-components": "0.11.28",
+        "@dtwebservices/task-presenter-components": "0.11.30",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/test-utils": "1.0.0-beta.29",
         "axios": "^0.20.0",
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@dtwebservices/task-presenter-components": {
-      "version": "0.11.28",
-      "resolved": "https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@dtwebservices/task-presenter-components/-/@dtwebservices/task-presenter-components-0.11.28.tgz",
-      "integrity": "sha512-30KokiOpTWINUAo5GuKiF9q9WZz5Kd2R0UkBYReR1FjlwlBfrg2J14qJoh4efyIUlm/vGoKFPQx8C2mBOyR7ow==",
+      "version": "0.11.30",
+      "resolved": "https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@dtwebservices/task-presenter-components/-/@dtwebservices/task-presenter-components-0.11.30.tgz",
+      "integrity": "sha512-Z02zepX4O2670clZiW0MBMuL0HzvqoiIlcycCxAX85TvvLNYsa3rpKnKbwYVQzn3aD5tIX/hXnakN8zhVSmGEw==",
       "dev": true,
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
@@ -17255,9 +17255,9 @@
       }
     },
     "@dtwebservices/task-presenter-components": {
-      "version": "0.11.28",
-      "resolved": "https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@dtwebservices/task-presenter-components/-/@dtwebservices/task-presenter-components-0.11.28.tgz",
-      "integrity": "sha512-30KokiOpTWINUAo5GuKiF9q9WZz5Kd2R0UkBYReR1FjlwlBfrg2J14qJoh4efyIUlm/vGoKFPQx8C2mBOyR7ow==",
+      "version": "0.11.30",
+      "resolved": "https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@dtwebservices/task-presenter-components/-/@dtwebservices/task-presenter-components-0.11.30.tgz",
+      "integrity": "sha512-Z02zepX4O2670clZiW0MBMuL0HzvqoiIlcycCxAX85TvvLNYsa3rpKnKbwYVQzn3aD5tIX/hXnakN8zhVSmGEw==",
       "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0",

--- a/static/src/package.json
+++ b/static/src/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@dtwebservices/task-presenter-components": "0.11.28",
+    "@dtwebservices/task-presenter-components": "0.11.30",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "axios": "^0.20.0",

--- a/static/src/yarn.lock
+++ b/static/src/yarn.lock
@@ -110,10 +110,10 @@
     "lodash" "^4.2.0"
     "to-fast-properties" "^2.0.0"
 
-"@dtwebservices/task-presenter-components@0.11.28":
-  "integrity" "sha512-30KokiOpTWINUAo5GuKiF9q9WZz5Kd2R0UkBYReR1FjlwlBfrg2J14qJoh4efyIUlm/vGoKFPQx8C2mBOyR7ow=="
-  "resolved" "https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@dtwebservices/task-presenter-components/-/@dtwebservices/task-presenter-components-0.11.28.tgz"
-  "version" "0.11.28"
+"@dtwebservices/task-presenter-components@0.11.30":
+  "integrity" "sha512-Z02zepX4O2670clZiW0MBMuL0HzvqoiIlcycCxAX85TvvLNYsa3rpKnKbwYVQzn3aD5tIX/hXnakN8zhVSmGEw=="
+  "resolved" "https://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@dtwebservices/task-presenter-components/-/@dtwebservices/task-presenter-components-0.11.30.tgz"
+  "version" "0.11.30"
   dependencies:
     "lodash.clonedeep" "^4.5.0"
     "lodash.flow" "^3.5.0"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-6793*

**Describe your changes**
A bug was discovered wherein if the `:annotation-url` prop was present but empty (`:annotation-url=''`), it would cause the `<anco>` helper component to crash upon loading. This change removes the prop if it is empty.

**Testing performed**
Tested locally, screenshots attached.

**1. When `:annotation-url` is NOT set:**

<img width="400" src="https://github.com/bloomberg/pybossa-default-theme/assets/486241/c9a5585f-0411-4edc-b728-a6475b712707" />


**2. When `:annotation-url` is set:**

<img width="400" src="https://github.com/bloomberg/pybossa-default-theme/assets/486241/19890ad3-4b3e-4b91-a274-e7e75582c494" />


