### PR TITLE
RDISCROWD-6970 add support for placeholder attr

### DIFF
--- a/static/src/components/setting/index.vue
+++ b/static/src/components/setting/index.vue
@@ -21,6 +21,7 @@
             <input
               v-if="field.type==='TextField'"
               v-model="externalConfigDict[field.name]"
+              :placeholder="field.label"
               type="text"
               class="form-control input-sm"
             >


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-6970*

**Describe your changes**
Add support for a placeholder attribute. `Wizard > Settings` does not currently have field labels for every input, and this can be confusing when there are multiple input fields.

**Testing performed (screenshot)**
![Screenshot 2024-02-02 at 4 29 49 PM](https://github.com/bloomberg/pybossa-default-theme/assets/486241/d1933e28-4ec4-4fd5-b5aa-73956e1ca6f7)

