### PR TITLE
RDISCROWD-7089 Usage stats to include project ids and project names

### DIFF
--- a/templates/admin/usage_dashboard.html
+++ b/templates/admin/usage_dashboard.html
@@ -51,8 +51,8 @@
                         <td>
                             <p>
                                 {% if value|length and value[0][1] != None %}
-                                    <a href="#" class="stat-link" data-toggle="modal" data-target="#statsModal" data-ids="{{ value[0][1] }}" data-names="{{ value[0][2] }}" data-owner-names="{{ value[0][4] }}" data-owner-emails="{{ value[0][5] }}">{{ value[0][0] }}</a>
-                                {% elif value[0]|length %}
+                                    <a href="#" class="stat-link" data-toggle="modal" data-target="#statsModal" data-ids="{{ value|map(attribute='1')|join(',') }}" data-names="{{ value|map(attribute='2')|join(',') }}" data-owner-names="{{ value|map(attribute='4')|join(',') }}" data-owner-emails="{{ value|map(attribute='5')|join(',') }}">{{ value|length }}</a>
+                                {% elif value|length %}
                                     {{ value[0][0] }}
                                 {% else %}
                                     0

--- a/templates/admin/usage_dashboard.html
+++ b/templates/admin/usage_dashboard.html
@@ -67,8 +67,17 @@
                             </button>
                         </div>
                         <div class="modal-body">
-                            <p id="project-ids"></p>
-                            <p id="project-names"></p>
+                            <table id="project-table" class="table table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>Project ID</th>
+                                        <th>Project Name</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <!-- Rows will be added dynamically -->
+                                </tbody>
+                            </table>
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
@@ -114,15 +123,18 @@ $(document).ready(function() {
     $('.stat-link').on('click', function(){
         var ids = `${$(this).data('ids')}`.split(',');
         var names = `${$(this).data('names')}`.split(',');
-        var idsHtml = 'Project IDs: ';
-        var namesHtml = 'Project Names: ';
+        var table = document.getElementById('project-table').getElementsByTagName('tbody')[0];
+        // Clear the table before adding new rows
+        table.innerHTML = '';
         for (var i = 0; i < ids.length; i++) {
-            idsHtml += '<a href="/projectid/' + ids[i].trim() + '">' + ids[i] + '</a>, ';
-            namesHtml += '<a href="/projectid/' + ids[i].trim() + '">' + names[i] + '</a>, ';
+            var row = table.insertRow();
+            var cell1 = row.insertCell(0);
+            var cell2 = row.insertCell(1);
+            cell1.textContent = ids[i].trim();
+            cell2.innerHTML = `<a href="/projectid/${ids[i].trim()}" target="_blank">${names[i]}</a>`;
         }
-        $('#project-ids').html(idsHtml.slice(0, -2));
-        $('#project-names').html(namesHtml.slice(0, -2));
     });
+
 })
 
 function redirect() {

--- a/templates/admin/usage_dashboard.html
+++ b/templates/admin/usage_dashboard.html
@@ -12,6 +12,12 @@
     .ct-line, .ct-point {
         stroke: #3AB0D5 !important;
     }
+    .modal-dialog .btn-secondary {
+        color: #505050;
+    }
+    .modal-dialog .btn-secondary:hover {
+        color: #000;
+    }
 </style>
 <div class="container">
     <div class="col-md-12" style="margin-top:30px;">
@@ -35,13 +41,13 @@
                 <thead>
                     <tr>
                         <th></th>
-                        <th><p id = table-header><strong></strong></p></th>
+                        <th><p class="table-header"><strong></strong></p></th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for stat, value in stats.items() %}
                     <tr>
-                        <th><p><strong>{{ stat | replace('_', ' ') }}</strong></p></th>
+                        <th><p class='row-heading'><strong>{{ stat | replace('_', ' ') }}</strong></p></th>
                         <td>
                             <p>
                                 {% if value|length and value[0][1] != None %}
@@ -59,11 +65,11 @@
             </table>
 
             <!-- Modal -->
-            <div class="modal fade" id="statsModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+            <div class="modal fade" id="statsModal" tabindex="-1" role="dialog" aria-labelledby="statsDetailLabel" aria-hidden="true">
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h5 class="modal-title" id="myModalLabel">Stat Details</h5>
+                            <h3 class="modal-title" id="statsDetailLabel">Projects Using: <span id='modal-subject'></span></h3>
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                                 <span aria-hidden="true">×</span>
                             </button>
@@ -118,30 +124,35 @@ $(document).ready(function() {
     timeframe_select.value = { '30': '30', '90': '90', '183': '183', '365': '365', 'all': 'all' }[days] || null;
 
     // set headers
-    let date_text = getFormatedStringFromDays(days)
-    document.getElementById('table-header').textContent = date_text;
+    const date_text = getFormatedStringFromDays(days)
+    document.getElementsByClassName('table-header')[0].textContent = date_text;
     document.getElementById('large-header').textContent += date_text;
 
     // Initialize count stats.
     $('.stat-link').on('click', function(){
-        var ids = `${$(this).data('ids')}`.split(',');
-        var names = `${$(this).data('names')}`.split(',');
-        var owner_names = `${$(this).data('owner-names')}`.split(',');
-        var owner_emails = `${$(this).data('owner-emails')}`.split(',');
-        var table = document.getElementById('project-table').getElementsByTagName('tbody')[0];
+        // Set modal title.
+        const title = $(this).closest('tr').find('.row-heading').text();
+        $('#modal-subject').text(title);
+
+        // Get data for table rows.
+        const ids = `${$(this).data('ids')}`.split(',');
+        const names = `${$(this).data('names')}`.split(',');
+        const owner_names = `${$(this).data('owner-names')}`.split(',');
+        const owner_emails = `${$(this).data('owner-emails')}`.split(',');
+        const table = document.getElementById('project-table').getElementsByTagName('tbody')[0];
+
         // Clear the table before adding new rows
         table.innerHTML = '';
-        for (var i = 0; i < ids.length; i++) {
-            var row = table.insertRow();
-            var cell1 = row.insertCell(0);
-            var cell2 = row.insertCell(1);
-            var cell3 = row.insertCell(2);
+        for (let i = 0; i < ids.length; i++) {
+            const row = table.insertRow();
+            const cell1 = row.insertCell(0);
+            const cell2 = row.insertCell(1);
+            const cell3 = row.insertCell(2);
             cell1.textContent = ids[i].trim();
             cell2.innerHTML = `<a href="/projectid/${ids[i].trim()}" target="_blank">${names[i]}</a>`;
             cell3.innerHTML = `<span title="${owner_emails[i]}">${owner_names[i]}</span>`;
         }
     });
-
 })
 
 function redirect() {

--- a/templates/admin/usage_dashboard.html
+++ b/templates/admin/usage_dashboard.html
@@ -44,10 +44,12 @@
                         <th><p><strong>{{ stat | replace('_', ' ') }}</strong></p></th>
                         <td>
                             <p>
-                                {% if value[0][1] != None %}
-                                    <a href="#" class="stat-link" data-toggle="modal" data-target="#statsModal" data-ids="{{ value[0][1] }}" data-names="{{ value[0][2] }}">{{ value[0][0] }}</a>
-                                {% else %}
+                                {% if value|length and value[0][1] != None %}
+                                    <a href="#" class="stat-link" data-toggle="modal" data-target="#statsModal" data-ids="{{ value[0][1] }}" data-names="{{ value[0][2] }}" data-owner-names="{{ value[0][4] }}" data-owner-emails="{{ value[0][5] }}">{{ value[0][0] }}</a>
+                                {% elif value[0]|length %}
                                     {{ value[0][0] }}
+                                {% else %}
+                                    0
                                 {% endif %}
                             </p>
                         </td>
@@ -72,6 +74,7 @@
                                     <tr>
                                         <th>Project ID</th>
                                         <th>Project Name</th>
+                                        <th>Owner</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -123,6 +126,8 @@ $(document).ready(function() {
     $('.stat-link').on('click', function(){
         var ids = `${$(this).data('ids')}`.split(',');
         var names = `${$(this).data('names')}`.split(',');
+        var owner_names = `${$(this).data('owner-names')}`.split(',');
+        var owner_emails = `${$(this).data('owner-emails')}`.split(',');
         var table = document.getElementById('project-table').getElementsByTagName('tbody')[0];
         // Clear the table before adding new rows
         table.innerHTML = '';
@@ -130,8 +135,10 @@ $(document).ready(function() {
             var row = table.insertRow();
             var cell1 = row.insertCell(0);
             var cell2 = row.insertCell(1);
+            var cell3 = row.insertCell(2);
             cell1.textContent = ids[i].trim();
             cell2.innerHTML = `<a href="/projectid/${ids[i].trim()}" target="_blank">${names[i]}</a>`;
+            cell3.innerHTML = `<span title="${owner_emails[i]}">${owner_names[i]}</span>`;
         }
     });
 

--- a/templates/admin/usage_dashboard.html
+++ b/templates/admin/usage_dashboard.html
@@ -31,22 +31,52 @@
 <div class="container">
     <div class="col-md-12">
         <h2 id ="large-header">{{ _('Platform Totals — ')}}</h2>
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th><p id = table-header><strong></strong></p></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for stat, value in stats.items() %}
-                <tr>
-                    <th><p><strong>{{ stat | replace('_', ' ') }}</strong></p></th>
-                    <td><p>{{ value[0][0] }} | {{ value[0][1] }} | {{ value[0][2] }}</p></td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th><p id = table-header><strong></strong></p></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for stat, value in stats.items() %}
+                    <tr>
+                        <th><p><strong>{{ stat | replace('_', ' ') }}</strong></p></th>
+                        <td>
+                            <p>
+                                {% if value[0][1] != None %}
+                                    <a href="#" class="stat-link" data-toggle="modal" data-target="#statsModal" data-ids="{{ value[0][1] }}" data-names="{{ value[0][2] }}">{{ value[0][0] }}</a>
+                                {% else %}
+                                    {{ value[0][0] }}
+                                {% endif %}
+                            </p>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            <!-- Modal -->
+            <div class="modal fade" id="statsModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="myModalLabel">Stat Details</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">×</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <p id="project-ids"></p>
+                            <p id="project-names"></p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- End of Modal -->
     </div>
 </div>
 <script>
@@ -79,6 +109,20 @@ $(document).ready(function() {
     let date_text = getFormatedStringFromDays(days)
     document.getElementById('table-header').textContent = date_text;
     document.getElementById('large-header').textContent += date_text;
+
+    // Initialize count stats.
+    $('.stat-link').on('click', function(){
+        var ids = `${$(this).data('ids')}`.split(',');
+        var names = `${$(this).data('names')}`.split(',');
+        var idsHtml = 'Project IDs: ';
+        var namesHtml = 'Project Names: ';
+        for (var i = 0; i < ids.length; i++) {
+            idsHtml += '<a href="/projectid/' + ids[i].trim() + '">' + ids[i] + '</a>, ';
+            namesHtml += '<a href="/projectid/' + ids[i].trim() + '">' + names[i] + '</a>, ';
+        }
+        $('#project-ids').html(idsHtml.slice(0, -2));
+        $('#project-names').html(namesHtml.slice(0, -2));
+    });
 })
 
 function redirect() {

--- a/templates/admin/usage_dashboard.html
+++ b/templates/admin/usage_dashboard.html
@@ -42,7 +42,7 @@
                 {% for stat, value in stats.items() %}
                 <tr>
                     <th><p><strong>{{ stat | replace('_', ' ') }}</strong></p></th>
-                    <td><p>{{ value }}</p></td>
+                    <td><p>{{ value[0][0] }} | {{ value[0][1] }} | {{ value[0][2] }}</p></td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
- Updated admin project stats usage dashboard to include project_ids and project_names, along with counts.

Re: https://github.com/bloomberg/pybossa/pull/903

## Screenshots

### The Usage Dashboard with clickable counts

![cap-1](https://github.com/bloomberg/pybossa-default-theme/assets/50708624/571df1ce-2376-4305-8fe4-2dd9b0e931d3)

### Project details for the statistic

![cap-2](https://github.com/bloomberg/pybossa-default-theme/assets/50708624/5dab10c1-9f0d-47dc-b3b6-d247a402c7fc)
