### PR TITLE
RDISCROWD-6334 add consensus methods

### DIFF
--- a/static/src/components/fieldsconfig/consensusMethods.js
+++ b/static/src/components/fieldsconfig/consensusMethods.js
@@ -4,7 +4,8 @@ const _types = {
   F1: 'f1',
   JACCARD: 'jaccard',
   DICE: 'dice',
-  MAJORITY: 'majority'
+  MAJORITY: 'majority',
+  OVERLAP: 'overlap'
 };
 
 const config = {
@@ -19,6 +20,9 @@ const config = {
   },
   [_types.MAJORITY]: {
     display: 'Majority',
+  },
+  [_types.OVERLAP]: {
+    display: 'Overlap',
   },
 };
 

--- a/static/src/components/fieldsconfig/consensusMethods.js
+++ b/static/src/components/fieldsconfig/consensusMethods.js
@@ -9,6 +9,9 @@ const _types = {
 };
 
 const config = {
+  [_types.MAJORITY]: {
+    display: 'Majority',
+  },
   [_types.F1]: {
     display: 'F1',
   },
@@ -17,9 +20,6 @@ const config = {
   },
   [_types.DICE]: {
     display: 'Dice',
-  },
-  [_types.MAJORITY]: {
-    display: 'Majority',
   },
   [_types.OVERLAP]: {
     display: 'Overlap',

--- a/static/src/components/fieldsconfig/consensusMethods.js
+++ b/static/src/components/fieldsconfig/consensusMethods.js
@@ -10,20 +10,20 @@ const _types = {
 
 const config = {
   [_types.MAJORITY]: {
-    display: 'Majority',
+    display: 'Majority'
   },
   [_types.F1]: {
-    display: 'F1',
+    display: 'F1'
   },
   [_types.JACCARD]: {
-    display: 'Jaccard',
+    display: 'Jaccard'
   },
   [_types.DICE]: {
-    display: 'Dice',
+    display: 'Dice'
   },
   [_types.OVERLAP]: {
-    display: 'Overlap',
-  },
+    display: 'Overlap'
+  }
 };
 
 export default {

--- a/static/src/components/fieldsconfig/consensusMethods.js
+++ b/static/src/components/fieldsconfig/consensusMethods.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const _types = {
+  F1: 'f1',
+  JACCARD: 'jaccard',
+  DICE: 'dice',
+  MAJORITY: 'majority'
+};
+
+const config = {
+  [_types.F1]: {
+    display: 'F1',
+  },
+  [_types.JACCARD]: {
+    display: 'Jaccard',
+  },
+  [_types.DICE]: {
+    display: 'Dice',
+  },
+  [_types.MAJORITY]: {
+    display: 'Majority',
+  },
+};
+
+export default {
+  default: _types.MAJORITY,
+  config
+};

--- a/static/src/components/fieldsconfig/consensus_config.vue
+++ b/static/src/components/fieldsconfig/consensus_config.vue
@@ -1,15 +1,26 @@
 <template>
-
   <div class="stats-config row">
-    <div v-if="hasRetryFields" class="col-md-12 consensus">
+    <div
+      v-if="hasRetryFields"
+      class="col-md-12 consensus"
+    >
       <h3> Consensus Config</h3>
       <div class="form-group row">
         <div class="col-md-4">
           <p> Consensus Method </p>
         </div>
         <div class="col-md-4">
-          <select id="consensus-method" v-model="consensusMethod" name="consensus-method" class="form-control input-sm">
-            <option v-for="(conf, type, index) in consensusMethods.config" :key="index" :value="type">
+          <select
+            id="consensus-method"
+            v-model="consensusMethod"
+            name="consensus-method"
+            class="form-control input-sm"
+          >
+            <option
+              v-for="(conf, type, index) in consensusMethods.config"
+              :key="index"
+              :value="type"
+            >
               {{ conf.display }}
             </option>
           </select>
@@ -20,7 +31,11 @@
           <p> Agreement Threshold </p>
         </div>
         <div class="col-md-8 pull-right">
-          <input v-model="agreementThreshold" type="text" class="form-control input-sm">
+          <input
+            v-model="agreementThreshold"
+            type="text"
+            class="form-control input-sm"
+          >
         </div>
       </div>
       <div class="form-group row">
@@ -28,7 +43,11 @@
           <p> Consensus Threshold </p>
         </div>
         <div class="col-md-8">
-          <input v-model="consensusThreshold" type="text" class="form-control input-sm">
+          <input
+            v-model="consensusThreshold"
+            type="text"
+            class="form-control input-sm"
+          >
         </div>
       </div>
       <div class="form-group row">
@@ -36,7 +55,11 @@
           <p> Add Redundancy To Retry </p>
         </div>
         <div class="col-md-8 pull-right">
-          <input v-model="redundancyConfig" type="text" class="form-control input-sm">
+          <input
+            v-model="redundancyConfig"
+            type="text"
+            class="form-control input-sm"
+          >
         </div>
       </div>
       <div class="form-group row">
@@ -44,16 +67,26 @@
           <p> Maximum Retry </p>
         </div>
         <div class="col-md-8 pull-right">
-          <input v-model="maxRetries" type="text" class="form-control input-sm">
+          <input
+            v-model="maxRetries"
+            type="text"
+            class="form-control input-sm"
+          >
         </div>
       </div>
     </div>
     <div class="col-md-12">
-      <div v-if="errorMsg" class="error-msg">
+      <div
+        v-if="errorMsg"
+        class="error-msg"
+      >
         {{ errorMsg }}
       </div>
       <div>
-        <button class="btn btn-sm btn-primary" @click="save">
+        <button
+          class="btn btn-sm btn-primary"
+          @click="save"
+        >
           Save
         </button>
       </div>
@@ -65,7 +98,7 @@
 import { mapGetters, mapMutations } from 'vuex';
 import consensusMethods from './consensusMethods';
 export default {
-  data() {
+  data () {
     return {
       consensusMethods,
       consensusThreshold: null,
@@ -74,7 +107,7 @@ export default {
       errorMsg: '',
       capacity: 10000,
       agreementThreshold: null,
-      consensusMethod: null,
+      consensusMethod: null
     };
   },
 
@@ -82,14 +115,14 @@ export default {
     ...mapGetters(['csrfToken', 'hasRetryFields', 'answerFields'])
   },
 
-  created() {
+  created () {
     this.getData();
   },
 
   methods: {
     ...mapMutations(['updateConsensusConfig', 'setData']),
 
-    initialize(data) {
+    initialize (data) {
       let config = JSON.parse(data.consensus_config);
       this.consensusThreshold = config.consensus_threshold;
       this.redundancyConfig = config.redundancy_config;
@@ -107,7 +140,7 @@ export default {
       return Math.floor(_n) === _n;
     },
 
-    getURL() {
+    getURL () {
       let path = window.location.pathname;
       let res = path.split('/');
       res[res.length - 1] = 'answerfieldsconfig';
@@ -138,7 +171,7 @@ export default {
       return true;
     },
 
-    async getData() {
+    async getData () {
       try {
         const res = await fetch(this.getURL(), {
           method: 'GET',
@@ -154,7 +187,7 @@ export default {
       }
     },
 
-    async save() {
+    async save () {
       let data = { answer_fields: this.answerFields };
       if (this.hasRetryFields) {
         let _consensusThreshold = parseInt(this.consensusThreshold, 10);
@@ -170,7 +203,7 @@ export default {
           'max_retries': _maxRetries,
           'redundancy_config': _redundancyConfig,
           'agreement_threshold': _agreementThreshold,
-          'consensus_method': _consensusMethod,
+          'consensus_method': _consensusMethod
         };
         this.updateConsensusConfig(data['consensus_config']);
       }

--- a/static/src/components/fieldsconfig/consensus_config.vue
+++ b/static/src/components/fieldsconfig/consensus_config.vue
@@ -150,7 +150,7 @@ export default {
     _write: function (_consensusThreshold, _redundancyConfig, _maxRetries, _agreementThreshold) {
       if (!this._isIntegerNumeric(_consensusThreshold) || _consensusThreshold <= 50 ||
         _consensusThreshold > 100) {
-        this.errorMsg = 'Threshold should be integer within 50 - 100';
+        this.errorMsg = 'Consensus Threshold should be integer within 50 - 100';
         return false;
       }
       if (!this._isIntegerNumeric(_redundancyConfig) || _redundancyConfig <= 0) {
@@ -162,9 +162,9 @@ export default {
         this.errorMsg = 'Maximum retries should be integer within 1 - ' + this.capacity;
         return false;
       }
-      if (!this._isIntegerNumeric(_agreementThreshold) || _agreementThreshold <= 0 ||
-        _agreementThreshold > this.capacity) {
-        this.errorMsg = 'Maximum agreement threshold should be integer within 1 - ' + this.capacity;
+      if (!this._isIntegerNumeric(_agreementThreshold) || _consensusThreshold <= 50 ||
+        _consensusThreshold > 100) {
+        this.errorMsg = 'Agreement Threshold should be integer within 50 - 100';
         return false;
       }
       this.errorMsg = '';

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -4,6 +4,7 @@
       id="answer-field-config"
       class="col-md-12"
     >
+    <h3>Answer Field Config</h3>
       <div
         class="form-group"
         :class="{'has-error': error}"

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -4,7 +4,7 @@
       id="answer-field-config"
       class="col-md-12"
     >
-    <h3>Answer Field Config</h3>
+      <h3>Answer Field Config</h3>
       <div
         class="form-group"
         :class="{'has-error': error}"

--- a/static/src/components/fieldsconfig/store.js
+++ b/static/src/components/fieldsconfig/store.js
@@ -15,6 +15,8 @@ function _updateConsensusConfig (state, config) {
   if (config) {
     const cf = {
       consensusThreshold: config['consensus_threshold'],
+      agreementThreshold: config['agreement_threshold'],
+      consensusMethod: config['consensus_method'],
       maxRetries: config['max_retries'],
       redundancyConfig: config['redundancy_config']
     };

--- a/static/src/test/components/fieldsconfig/consensus_config.spec.js
+++ b/static/src/test/components/fieldsconfig/consensus_config.spec.js
@@ -78,7 +78,7 @@ describe('ConsensusConfig', () => {
     });
     const wrapper = shallowMount(ConsensusConfig, { store, localVue });
     const p = wrapper.findAll('p');
-    expect(p).toHaveLength(3);
+    expect(p).toHaveLength(5);
   });
 
   it('load non-empty config', () => {
@@ -98,7 +98,7 @@ describe('ConsensusConfig', () => {
     const p = wrapper.findAll('p');
     const button = wrapper.findAll('button');
     expect(button).toHaveLength(1);
-    expect(p).toHaveLength(3);
+    expect(p).toHaveLength(5);
   });
 
   it('save config (without consensus config)', async () => {

--- a/static/src/test/components/fieldsconfig/consensus_config.spec.js
+++ b/static/src/test/components/fieldsconfig/consensus_config.spec.js
@@ -174,33 +174,6 @@ describe('ConsensusConfig', () => {
     expect(wrapper.findAll('.error-msg')).toHaveLength(1);
   });
 
-  // it('save incorrect config', () => {
-  //   const propsData = {
-  //     consensusConfig: { consensus_threshold: 70, max_retries: 0, redundancy_config: 0 }
-  //   };
-  //   store.commit('setData', {
-  //     answerFields: {
-  //       testField: {
-  //         type: 'categorical',
-  //         config: {
-  //           labels: ['A', 'B', 'C']
-  //         },
-  //         retry_for_consensus: true
-  //       }
-  //     },
-  //     consensus: {
-  //       consensus_threshold: 70,
-  //       max_retries: 0,
-  //       redundancy_config: 0
-  //     }
-  //   });
-  //   const wrapper = shallowMount(ConsensusConfig, { store, localVue, propsData });
-  //   expect(wrapper.findAll('.error-msg')).toHaveLength(0);
-  //   const saveButton = wrapper.findAll('button').at(0);
-  //   saveButton.trigger('click');
-  //   expect(wrapper.findAll('.error-msg')).toHaveLength(1);
-  // });
-
   it('save config fails', async () => {
     fetch.mockImplementation((arg) => ({
       ok: false
@@ -223,4 +196,19 @@ describe('ConsensusConfig', () => {
     expect(fetch.mock.calls).toHaveLength(2);
     expect(notify.mock.calls).toHaveLength(2);
   });
+
+  it('test validation logic directly', () => {
+    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    let valid = wrapper.vm._write(80, 2, 10, 70); // should pass
+    expect(valid).toBe(true);
+
+    valid = wrapper.vm._write(101, 2, 10, 70); // threshold out of range
+    expect(valid).toBe(false);
+    expect(wrapper.vm.errorMsg).toContain('within 50 - 100');
+
+    valid = wrapper.vm._write(80, -1, 10, 70); // redundancy should be positive
+    expect(valid).toBe(false);
+    expect(wrapper.vm.errorMsg).toContain('positive integer');
+  });
+
 });

--- a/static/src/test/components/fieldsconfig/consensus_config.spec.js
+++ b/static/src/test/components/fieldsconfig/consensus_config.spec.js
@@ -210,5 +210,4 @@ describe('ConsensusConfig', () => {
     expect(valid).toBe(false);
     expect(wrapper.vm.errorMsg).toContain('positive integer');
   });
-
 });


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-6334*

**Describe your changes**
 - Add UI options in project settings -> Answer for new consensus methods
 - Consensus Method: how to calculate consensus
    - options: F1, Jaccard, Dice, Overlap, Majority
 - Agreement threshold: what percentage of the two answers must match for agreement (pairwise comparison)
 - Consensus threshold: what total percentage of answers need to match for there to be consensus or not
    - Determines if redundancy will be updated
![image](https://github.com/bloomberg/pybossa-default-theme/assets/17805819/c4725e1e-02e0-4607-a572-baff30c5942d)

example project:

```
{
  "id": 1,
  "created": "2024-04-25T19:50:45.592631",
  "updated": "2024-05-06T15:14:15.176278",
  "name": "Location Pref Test",
  "short_name": "locationpreftest",
  "description": "test location pref",
  "long_description": "test location pref",
  "answer_fields": {
    "test": {
      "type": "categorical",
      "config": {
        "labels": []
      },
      "retry_for_consensus": true
    }
  },
  "reserve_tasks": {
    "category": []
  },
  "consensus_config": {
    "max_retries": 10,
    "consensus_method": "jaccard",
    "redundancy_config": 1,
    "agreement_threshold": 75,
    "consensus_threshold": 51
  }
}
```

**Testing performed**
Tested Locally

**Additional context**
https://jira.prod.bloomberg.com/browse/RDISCROWD-6335
