### PR TITLE
Rdiscrowd 6334 v2

### DIFF
--- a/static/src/answerfieldsconfig.js
+++ b/static/src/answerfieldsconfig.js
@@ -3,7 +3,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import FieldsConfig from './components/fieldsconfig/index';
-import ConsensusConfig from './components/fieldsconfig/consensus_config';
+import RedundancyConfig from './components/fieldsconfig/redundancy_config';
 import { storeSpecs } from './components/fieldsconfig/store';
 
 Vue.use(Vuex);
@@ -15,7 +15,7 @@ const app = new Vue({
   store,
   components: {
     FieldsConfig,
-    ConsensusConfig
+    RedundancyConfig
   }
 });
 

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -4,6 +4,7 @@
       id="answer-field-config"
       class="col-md-12"
     >
+    <h3>Answer Field Config</h3>
       <div
         class="form-group"
         :class="{'has-error': error}"

--- a/static/src/components/fieldsconfig/index.vue
+++ b/static/src/components/fieldsconfig/index.vue
@@ -4,7 +4,7 @@
       id="answer-field-config"
       class="col-md-12"
     >
-    <h3>Answer Field Config</h3>
+      <h3>Answer Field Config</h3>
       <div
         class="form-group"
         :class="{'has-error': error}"

--- a/static/src/components/fieldsconfig/redundancy_config.vue
+++ b/static/src/components/fieldsconfig/redundancy_config.vue
@@ -6,6 +6,7 @@
       v-if="hasRetryFields"
       class="col-md-12 consensus"
     >
+    <h3>Redundancy Config</h3>
       <div class="form-group row">
         <div class="col-md-4">
           <p> Consensus Threshold </p>
@@ -85,7 +86,7 @@ export default {
   },
 
   methods: {
-    ...mapMutations(['updateConsensusConfig', 'setData']),
+    ...mapMutations(['updateRedundancyConfig', 'setData']),
 
     initialize (data) {
       let config = JSON.parse(data.consensus_config);
@@ -154,12 +155,12 @@ export default {
             if (!this._write(_consensusThreshold, _redundancyConfig, _maxRetries)) {
                 return;
             }
-            data['consensus_config'] = {
+            data['redundancy_config'] = {
                     'consensus_threshold': _consensusThreshold,
                     'max_retries': _maxRetries,
                     'redundancy_config': _redundancyConfig
                   };
-            this.updateConsensusConfig(data['consensus_config']);
+            this.updateRedundancyConfig(data['redundancy_config']);
         }
         try {
             const res = await fetch(this.getURL(), {

--- a/static/src/components/fieldsconfig/redundancy_config.vue
+++ b/static/src/components/fieldsconfig/redundancy_config.vue
@@ -78,7 +78,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['csrfToken', 'hasRetryFields', 'answerFields'])
+    ...mapGetters(['csrfToken', 'hasRetryFields', 'answerFields', 'consensusConfig'])
   },
 
   created () {
@@ -86,18 +86,16 @@ export default {
   },
 
   methods: {
-    ...mapMutations(['updateRedundancyConfig', 'setData']),
+    ...mapMutations(['setCSRF', 'updateRedundancyConfig', 'setAnswerFields']),
 
     initialize (data) {
       let config = JSON.parse(data.consensus_config);
       this.consensusThreshold = config.consensus_threshold;
       this.redundancyConfig = config.redundancy_config;
       this.maxRetries = config.max_retries;
-      this.setData({
-        csrf: data.csrf,
-        answerFields: JSON.parse(data.answer_fields),
-        consensus: config
-      });
+      this.setCSRF(data.csrf);
+      this.updateRedundancyConfig(config);
+      this.setAnswerFields(JSON.parse(data.answer_fields));
     },
 
     _isIntegerNumeric: function (_n) {
@@ -159,7 +157,9 @@ export default {
             data['consensus_config'] = {
                     'consensus_threshold': _consensusThreshold,
                     'max_retries': _maxRetries,
-                    'redundancy_config': _redundancyConfig
+                    'redundancy_config': _redundancyConfig,
+                    'consensus_method': this.consensusConfig.consensusMethod,
+                    'agreement_threshold': this.consensusConfig.agreementThreshold
                   };
             this.updateRedundancyConfig(data['consensus_config']);
         }

--- a/static/src/components/fieldsconfig/redundancy_config.vue
+++ b/static/src/components/fieldsconfig/redundancy_config.vue
@@ -6,7 +6,7 @@
       v-if="hasRetryFields"
       class="col-md-12 consensus"
     >
-    <h3>Redundancy Config</h3>
+      <h3>Redundancy Config</h3>
       <div class="form-group row">
         <div class="col-md-4">
           <p> Consensus Threshold </p>
@@ -143,6 +143,7 @@ export default {
         this.initialize(data);
       } catch (error) {
         window.pybossaNotify('An error occurred.', true, 'error');
+        console.log(error);
       }
     },
 
@@ -155,12 +156,12 @@ export default {
             if (!this._write(_consensusThreshold, _redundancyConfig, _maxRetries)) {
                 return;
             }
-            data['redundancy_config'] = {
+            data['consensus_config'] = {
                     'consensus_threshold': _consensusThreshold,
                     'max_retries': _maxRetries,
                     'redundancy_config': _redundancyConfig
                   };
-            this.updateRedundancyConfig(data['redundancy_config']);
+            this.updateRedundancyConfig(data['consensus_config']);
         }
         try {
             const res = await fetch(this.getURL(), {

--- a/static/src/components/fieldsconfig/store.js
+++ b/static/src/components/fieldsconfig/store.js
@@ -14,9 +14,9 @@ function _addField (state, { name, type, config, retryForConsensus, newField = f
 function _updateRedundancyConfig (state, config) {
   if (config) {
     const cf = {
-      consensus_threshold: config['consensus_threshold'],
-      max_retries: config['max_retries'],
-      redundancy_config: config['redundancy_config']
+      consensusThreshold: config['consensus_threshold'],
+      maxRetries: config['max_retries'],
+      redundancyConfig: config['redundancy_config']
     };
     state.redundancyConfig = cf;
   }
@@ -25,7 +25,7 @@ function _updateRedundancyConfig (state, config) {
 function _updateConsensusConfig (state, config) {
   if (config) {
     const cf = {
-      consensus_method: config['consensusMethod'],
+      consensusMethod: config['consensus_method'],
       agreementThreshold: config['agreement_threshold']
     };
     state.consensusConfig = cf;
@@ -48,6 +48,7 @@ const storeSpecs = {
     fieldNames: [],
     answerFields: {},
     consensusConfig: {},
+    redundancyConfig: {},
     newFields: {},
     showWarning: false
   },
@@ -81,6 +82,14 @@ const storeSpecs = {
 
     showWarning (state) {
       return state.showWarning;
+    },
+
+    redundancyConfig (state) {
+      return state.redundancyConfig;
+    },
+
+    consensusConfig (state) {
+      return state.consensusConfig;
     }
   },
 
@@ -114,6 +123,18 @@ const storeSpecs = {
 
     changeRetryConfig (state, { name, retry }) {
       state.answerFields[name]['retry_for_consensus'] = retry;
+    },
+
+    setCSRF (state, csrf) {
+      state.csrf = csrf;
+    },
+
+    setAnswerFields (state, answerFields) {
+      for (const name in answerFields) {
+        const retryForConsensus = answerFields[name]['retry_for_consensus'];
+        const { type, config } = answerFields[name];
+        _addField(state, { name, type, config, retryForConsensus });
+      }
     },
 
     setData (state, { csrf, answerFields, config }) {

--- a/static/src/components/fieldsconfig/store.js
+++ b/static/src/components/fieldsconfig/store.js
@@ -11,7 +11,7 @@ function _addField (state, { name, type, config, retryForConsensus, newField = f
   state.fieldNames.push(name);
 }
 
-function _updateConsensusConfig (state, config) {
+function _updateRedundancyConfig (state, config) {
   if (config) {
     const cf = {
       consensusThreshold: config['consensus_threshold'],
@@ -94,8 +94,8 @@ const storeSpecs = {
       delete state.answerFields[name];
     },
 
-    updateConsensusConfig (state, config) {
-      _updateConsensusConfig(state, config);
+    updateRedundancyConfig (state, config) {
+      _updateRedundancyConfig(state, config);
     },
 
     changeRetryConfig (state, { name, retry }) {
@@ -110,7 +110,7 @@ const storeSpecs = {
         const { type, config } = fields[name];
         _addField(state, { name, type, config, retryForConsensus });
       }
-      _updateConsensusConfig(state, consensus);
+      _updateRedundancyConfig(state, consensus);
     }
   }
 };

--- a/static/src/components/fieldsconfig/store.js
+++ b/static/src/components/fieldsconfig/store.js
@@ -14,9 +14,19 @@ function _addField (state, { name, type, config, retryForConsensus, newField = f
 function _updateRedundancyConfig (state, config) {
   if (config) {
     const cf = {
-      consensusThreshold: config['consensus_threshold'],
-      maxRetries: config['max_retries'],
-      redundancyConfig: config['redundancy_config']
+      consensus_threshold: config['consensus_threshold'],
+      max_retries: config['max_retries'],
+      redundancy_config: config['redundancy_config']
+    };
+    state.redundancyConfig = cf;
+  }
+}
+
+function _updateConsensusConfig (state, config) {
+  if (config) {
+    const cf = {
+      consensus_method: config['consensusMethod'],
+      agreementThreshold: config['agreement_threshold']
     };
     state.consensusConfig = cf;
   }
@@ -98,11 +108,15 @@ const storeSpecs = {
       _updateRedundancyConfig(state, config);
     },
 
+    updateConsensusConfig (state, config) {
+      _updateConsensusConfig(state, config);
+    },
+
     changeRetryConfig (state, { name, retry }) {
       state.answerFields[name]['retry_for_consensus'] = retry;
     },
 
-    setData (state, { csrf, answerFields, consensus }) {
+    setData (state, { csrf, answerFields, config }) {
       state.csrf = csrf;
       const fields = answerFields;
       for (const name in fields) {
@@ -110,7 +124,7 @@ const storeSpecs = {
         const { type, config } = fields[name];
         _addField(state, { name, type, config, retryForConsensus });
       }
-      _updateRedundancyConfig(state, consensus);
+      _updateRedundancyConfig(state, config);
     }
   }
 };

--- a/static/src/components/setting/consensusMethods.js
+++ b/static/src/components/setting/consensusMethods.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const _types = {
+  F1: 'f1',
+  JACCARD: 'jaccard',
+  DICE: 'dice',
+  MAJORITY: 'majority',
+  OVERLAP: 'overlap'
+};
+
+const config = {
+  [_types.MAJORITY]: {
+    display: 'Majority'
+  },
+  [_types.F1]: {
+    display: 'F1'
+  },
+  [_types.JACCARD]: {
+    display: 'Jaccard'
+  },
+  [_types.DICE]: {
+    display: 'Dice'
+  },
+  [_types.OVERLAP]: {
+    display: 'Overlap'
+  }
+};
+
+export default {
+  default: _types.MAJORITY,
+  config
+};

--- a/static/src/components/setting/consensusMethods.js
+++ b/static/src/components/setting/consensusMethods.js
@@ -8,6 +8,11 @@ const _types = {
   OVERLAP: 'overlap'
 };
 
+function isPairwiseConsensus (consensusType) {
+  const pairwiseFunctions = [_types.F1, _types.JACCARD, _types.DICE, _types.OVERLAP];
+  return pairwiseFunctions.includes(consensusType);
+}
+
 const config = {
   [_types.MAJORITY]: {
     display: 'Majority'
@@ -28,5 +33,6 @@ const config = {
 
 export default {
   default: _types.MAJORITY,
-  config
+  config,
+  isPairwiseConsensus
 };

--- a/static/src/components/setting/consensus_setting.vue
+++ b/static/src/components/setting/consensus_setting.vue
@@ -1,0 +1,182 @@
+<template>
+  <div class="stats-config row">
+    <h3> Consensus Config</h3>
+    <div class="form-group row">
+      <div class="col-md-4">
+        <p> Consensus Method </p>
+      </div>
+      <div class="col-md-4">
+        <select
+          id="consensus-method"
+          v-model="consensusMethod"
+          name="consensus-method"
+          class="form-control input-sm"
+        >
+          <option
+            v-for="(conf, type, index) in consensusMethods.config"
+            :key="index"
+            :value="type"
+          >
+            {{ conf.display }}
+          </option>
+        </select>
+      </div>
+    </div>
+    <div class="form-group row">
+      <div class="col-md-4">
+        <p> Agreement Threshold </p>
+      </div>
+      <div class="col-md-8 pull-right">
+        <input
+          v-model="agreementThreshold"
+          type="text"
+          class="form-control input-sm"
+        >
+      </div>
+    </div>
+    <div class="col-md-12">
+      <div
+        v-if="errorMsg"
+        class="error-msg"
+      >
+        {{ errorMsg }}
+      </div>
+      <div>
+        <button
+          class="btn btn-sm btn-primary"
+          @click="save"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+
+import { mapGetters, mapMutations } from 'vuex';
+import consensusMethods from './consensusMethods';
+
+export default {
+    data () {
+        return {
+            consensusMethods,
+            consensusMethod: null,
+            agreementThreshold: null,
+            errorMsg: ''
+        };
+    },
+
+    computed: {
+        ...mapGetters(['csrfToken'])
+    },
+
+    created () {
+        this.getData();
+    },
+
+    methods: {
+        ...mapMutations(['updateConsensusConfig', 'setData']),
+
+        initialize (data) {
+            let config = JSON.parse(data.consensus_config);
+            this.consensusMethod = config.consensus_method;
+            this.agreementThreshold = config.agreement_threshold;
+            this.setData({
+                csrf: data.csrf,
+                consensus: config
+            });
+        },
+
+        _isIntegerNumeric: function (_n) {
+            return Math.floor(_n) === _n;
+        },
+
+        getURL () {
+            let path = window.location.pathname;
+            let res = path.split('/');
+            res[res.length - 1] = 'answerfieldsconfig';
+            return res.join('/');
+        },
+
+        _write: function (_agreementThreshold) {
+            if (!this._isIntegerNumeric(_agreementThreshold) || _agreementThreshold <= 50 ||
+                _agreementThreshold > 100) {
+                this.errorMsg = 'Agreement Threshold should be integer within 50 - 100';
+                return false;
+            }
+            this.errorMsg = '';
+            return true;
+        },
+
+        async getData () {
+            try {
+                const res = await fetch(this.getURL(), {
+                    method: 'GET',
+                    headers: {
+                        'content-type': 'application/json'
+                    },
+                    credentials: 'same-origin'
+                });
+                const data = await res.json();
+                print('consnss confg got dataa:', data);
+                this.initialize(data);
+            } catch (error) {
+                window.pybossaNotify('An error occurred.', true, 'error');
+                console.log(error);
+            }
+        },
+
+        async save () {
+            let _agreementThreshold = parseInt(this.agreementThreshold, 10);
+            let _consensusMethod = parseInt(this.consensusMethod, 'majority');
+            if (!this._write(_agreementThreshold)) {
+                return;
+            }
+            let data = {
+                'consensus_config': {
+                    'agreement_threshold': _agreementThreshold,
+                    'consensus_method': _consensusMethod
+                }
+            };
+            this.updateConsensusConfig(data['consensus_config']);
+            try {
+                const res = await fetch(this.getURL(), {
+                    method: 'POST',
+                    headers: {
+                        'content-type': 'application/json',
+                        'X-CSRFToken': this.csrfToken
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify(data)
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    window.pybossaNotify(data['flash'], true, data['status']);
+                } else {
+                    window.pybossaNotify('An error occurred configuring consensus settings.', true, 'error');
+                }
+            } catch (error) {
+                window.pybossaNotify('An error occurred configuring answer consensus settings.', true, 'error');
+            }
+        }
+    }
+};
+</script>
+<style scoped>
+.error-msg {
+    color: red;
+}
+
+.form-control.input-sm {
+    width: 280px;
+}
+
+.align-right {
+    text-align: right;
+}
+
+.consensus {
+    width: 85%
+}
+</style>

--- a/static/src/setting.js
+++ b/static/src/setting.js
@@ -6,6 +6,7 @@ import ownershipSetting from './components/setting/ownership_setting.vue';
 import Vuex from 'vuex';
 import FieldsConfig from './components/fieldsconfig/index';
 import RedundancyConfig from './components/fieldsconfig/redundancy_config';
+import ConsensusSetting from './components/setting/consensus_setting';
 import { storeSpecs } from './components/fieldsconfig/store';
 
 Vue.use(Vuex);
@@ -21,7 +22,8 @@ const app = new Vue({
     setting,
     taskSetting,
     quizSetting,
-    ownershipSetting
+    ownershipSetting,
+    ConsensusSetting
   }
 });
 

--- a/static/src/setting.js
+++ b/static/src/setting.js
@@ -5,7 +5,7 @@ import quizSetting from './components/setting/quiz_setting.vue';
 import ownershipSetting from './components/setting/ownership_setting.vue';
 import Vuex from 'vuex';
 import FieldsConfig from './components/fieldsconfig/index';
-import ConsensusConfig from './components/fieldsconfig/consensus_config';
+import RedundancyConfig from './components/fieldsconfig/redundancy_config';
 import { storeSpecs } from './components/fieldsconfig/store';
 
 Vue.use(Vuex);
@@ -17,7 +17,7 @@ const app = new Vue({
   store,
   components: {
     FieldsConfig,
-    ConsensusConfig,
+    RedundancyConfig,
     setting,
     taskSetting,
     quizSetting,

--- a/static/src/test/components/fieldsconfig/redundancy_config.spec.js
+++ b/static/src/test/components/fieldsconfig/redundancy_config.spec.js
@@ -1,13 +1,13 @@
 import Vuex from 'vuex';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import ConsensusConfig from '../../../components/fieldsconfig/consensus_config.vue';
+import RedundancyConfig from '../../../components/fieldsconfig/redundancy_config.vue';
 import { storeSpecs } from '../../../components/fieldsconfig/store';
 import { cloneDeep } from 'lodash';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-describe('ConsensusConfig', () => {
+describe('RedundancyConfig', () => {
   let store;
   let fetch;
   let notify;
@@ -25,7 +25,7 @@ describe('ConsensusConfig', () => {
 
   it('fetch data', async () => {
     let response = {
-      consensus_config: JSON.stringify(consensusConfig),
+      redundancy_config: JSON.stringify(consensusConfig),
       answer_fields: {
         testField: {
           type: 'categorical',
@@ -40,7 +40,7 @@ describe('ConsensusConfig', () => {
       ok: true,
       json: () => Promise.resolve(response)
     }));
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     await localVue.nextTick();
     expect(wrapper.vm._data.consensusThreshold).toBe(80);
     expect(wrapper.vm._data.redundancyConfig).toBe(2);
@@ -59,7 +59,7 @@ describe('ConsensusConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     const p = wrapper.findAll('p');
     expect(p).toHaveLength(0);
   });
@@ -76,7 +76,7 @@ describe('ConsensusConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     const p = wrapper.findAll('p');
     expect(p).toHaveLength(3);
   });
@@ -94,7 +94,7 @@ describe('ConsensusConfig', () => {
       },
       consensus: consensusConfig
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     const p = wrapper.findAll('p');
     const button = wrapper.findAll('button');
     expect(button).toHaveLength(1);
@@ -117,7 +117,7 @@ describe('ConsensusConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
     await localVue.nextTick();
@@ -142,7 +142,7 @@ describe('ConsensusConfig', () => {
       },
       consensus: consensusConfig
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
     await localVue.nextTick();
@@ -167,7 +167,7 @@ describe('ConsensusConfig', () => {
         redundancy_config: 'wrong'
       }
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     expect(wrapper.findAll('.error-msg')).toHaveLength(0);
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
@@ -194,7 +194,7 @@ describe('ConsensusConfig', () => {
   //       redundancy_config: 0
   //     }
   //   });
-  //   const wrapper = shallowMount(ConsensusConfig, { store, localVue, propsData });
+  //   const wrapper = shallowMount(RedundancyConfig, { store, localVue, propsData });
   //   expect(wrapper.findAll('.error-msg')).toHaveLength(0);
   //   const saveButton = wrapper.findAll('button').at(0);
   //   saveButton.trigger('click');
@@ -216,7 +216,7 @@ describe('ConsensusConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
+    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
     await localVue.nextTick();

--- a/static/src/test/components/setting/consensus_setting.spec.js
+++ b/static/src/test/components/setting/consensus_setting.spec.js
@@ -1,67 +1,25 @@
 import Vuex from 'vuex';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import RedundancyConfig from '../../../components/fieldsconfig/redundancy_config.vue';
+import ConsensusConfig from '../../../components/setting/consensus_setting.vue';
 import { storeSpecs } from '../../../components/fieldsconfig/store';
 import { cloneDeep } from 'lodash';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-describe('RedundancyConfig', () => {
+describe('ConsensusConfig', () => {
   let store;
   let fetch;
   let notify;
   let consensusConfig = {
-    consensus_threshold: 80,
-    redundancy_config: 2,
-    max_retries: 10
+    consensus_method: "dice",
+    agreement_threshold: 80
   };
 
   beforeEach(() => {
     store = new Vuex.Store(cloneDeep(storeSpecs));
     fetch = global.fetch = jest.fn();
     notify = window.pybossaNotify = jest.fn();
-  });
-
-  it('fetch data', async () => {
-    let response = {
-      consensus_config: JSON.stringify(consensusConfig),
-      answer_fields: {
-        testField: {
-          type: 'categorical',
-          config: {
-            labels: ['A', 'B', 'C']
-          },
-          retryForConsensus: false
-        }
-      }
-    };
-    fetch.mockImplementation((arg) => ({
-      ok: true,
-      json: () => Promise.resolve(response)
-    }));
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
-    await localVue.nextTick();
-    expect(wrapper.vm._data.consensusThreshold).toBe(80);
-    expect(wrapper.vm._data.redundancyConfig).toBe(2);
-    expect(wrapper.vm._data.maxRetries).toBe(10);
-  });
-
-  it('does not load data', () => {
-    store.commit('setData', {
-      answerFields: {
-        testField: {
-          type: 'categorical',
-          config: {
-            labels: ['A', 'B', 'C']
-          },
-          retryForConsensus: false
-        }
-      }
-    });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
-    const p = wrapper.findAll('p');
-    expect(p).toHaveLength(0);
   });
 
   it('loads empty config', () => {
@@ -76,9 +34,9 @@ describe('RedundancyConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
+    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
     const p = wrapper.findAll('p');
-    expect(p).toHaveLength(3);
+    expect(p).toHaveLength(1);
   });
 
   it('load non-empty config', () => {
@@ -94,11 +52,11 @@ describe('RedundancyConfig', () => {
       },
       consensus: consensusConfig
     });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
+    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
     const p = wrapper.findAll('p');
     const button = wrapper.findAll('button');
     expect(button).toHaveLength(1);
-    expect(p).toHaveLength(3);
+    expect(p).toHaveLength(1);
   });
 
   it('save config (without consensus config)', async () => {
@@ -117,7 +75,7 @@ describe('RedundancyConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
+    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
     await localVue.nextTick();
@@ -142,36 +100,12 @@ describe('RedundancyConfig', () => {
       },
       consensus: consensusConfig
     });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
+    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
     await localVue.nextTick();
     expect(fetch.mock.calls).toHaveLength(2);
     expect(notify.mock.calls).toHaveLength(2);
-  });
-
-  it('save incorrect config', () => {
-    store.commit('setData', {
-      answerFields: {
-        testField: {
-          type: 'categorical',
-          config: {
-            labels: ['A', 'B', 'C']
-          },
-          retry_for_consensus: true
-        }
-      },
-      consensus: {
-        consensus_threshold: 80,
-        max_retries: 8,
-        redundancy_config: 'wrong'
-      }
-    });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
-    expect(wrapper.findAll('.error-msg')).toHaveLength(0);
-    const saveButton = wrapper.findAll('button').at(0);
-    saveButton.trigger('click');
-    expect(wrapper.findAll('.error-msg')).toHaveLength(1);
   });
 
   it('save config fails', async () => {
@@ -189,25 +123,11 @@ describe('RedundancyConfig', () => {
         }
       }
     });
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
+    const wrapper = shallowMount(ConsensusConfig, { store, localVue });
     const saveButton = wrapper.findAll('button').at(0);
     saveButton.trigger('click');
     await localVue.nextTick();
     expect(fetch.mock.calls).toHaveLength(2);
     expect(notify.mock.calls).toHaveLength(2);
-  });
-
-  it('test validation logic directly', () => {
-    const wrapper = shallowMount(RedundancyConfig, { store, localVue });
-    let valid = wrapper.vm._write(80, 2, 10, 70); // should pass
-    expect(valid).toBe(true);
-
-    valid = wrapper.vm._write(101, 2, 10, 70); // threshold out of range
-    expect(valid).toBe(false);
-    expect(wrapper.vm.errorMsg).toContain('within 50 - 100');
-
-    valid = wrapper.vm._write(80, -1, 10, 70); // redundancy should be positive
-    expect(valid).toBe(false);
-    expect(wrapper.vm.errorMsg).toContain('positive integer');
   });
 });

--- a/static/src/test/components/setting/consensus_setting.spec.js
+++ b/static/src/test/components/setting/consensus_setting.spec.js
@@ -12,7 +12,7 @@ describe('ConsensusConfig', () => {
   let fetch;
   let notify;
   let consensusConfig = {
-    consensus_method: "dice",
+    consensus_method: 'dice',
     agreement_threshold: 80
   };
 

--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -13,18 +13,18 @@
             <fields-config > </fields-config>
         </div>
         <div>
-            <consensus-config :consensus-config="{{consensus_config}}"></consensus-config>
+            <redundancy-config :redundancy-config="{{redundancy_config}}"></redundancy-config>
         </div>
     </div>
 </div>
 
-<script src="/static/js/gen/answerfieldsconfig.min.46f9044b63239b7aa911.js"></script>
+<script src="/static/js/gen/answerfieldsconfig.min.1faeb808b925ee3acc5c.js"></script>
 
 <script>
 answerFields.setData({
     csrf: '{{csrf}}',
     answerFields: {{answer_fields | safe}},
-    consensus: {{consensus_config | safe}}
+    consensus: {{redundancy_config | safe}}
 });
 </script>
 {% endblock %}

--- a/templates/projects/answerfieldsconfig.webpack.ejs
+++ b/templates/projects/answerfieldsconfig.webpack.ejs
@@ -13,7 +13,7 @@
             <fields-config > </fields-config>
         </div>
         <div>
-            <consensus-config :consensus-config="{{consensus_config}}"></consensus-config>
+            <redundancy-config :redundancy-config="{{redundancy_config}}"></redundancy-config>
         </div>
     </div>
 </div>
@@ -24,7 +24,7 @@
 answerFields.setData({
     csrf: '{{csrf}}',
     answerFields: {{answer_fields | safe}},
-    consensus: {{consensus_config | safe}}
+    consensus: {{redundancy_config | safe}}
 });
 </script>
 {% endblock %}

--- a/templates/projects/summary.html
+++ b/templates/projects/summary.html
@@ -9,6 +9,7 @@
         <li role="presentation"><a href="#task" aria-controls="task" role="tab" data-toggle="tab">Task</a></li>
         <li role="presentation"><a href="#answer" aria-controls="answer" role="tab" data-toggle="tab">Answer</a></li>
         <li role="presentation"><a href="#quiz" aria-controls="quiz" role="tab" data-toggle="tab">Quiz</a></li>
+        <li role="presentation"><a href="#consensus" aria-controls="consensus" role="tab" data-toggle="tab">Consensus</a></li>
     </ul>
     <br>
 
@@ -51,10 +52,20 @@
                 </div>
             </div>
         </div>
+
+        <div role="tabpanel" class="tab-pane fade" id="consensus">
+            <div class="col-md-12">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <consensus-setting></consensus-setting>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 
-<script src="/static/js/gen/setting.min.1faeb808b925ee3acc5c.js"></script>
+<script src="/static/js/gen/setting.min.692ba830e062417ac25f.js"></script>
 
 {% endblock %}
 

--- a/templates/projects/summary.html
+++ b/templates/projects/summary.html
@@ -37,7 +37,7 @@
                     <fields-config></fields-config>
                 </div>
                 <div>
-                    <consensus-config></consensus-config>
+                    <redundancy-config></redundancy-config>
                 </div>
             </div>
         </div>
@@ -54,7 +54,7 @@
     </div>
 </div>
 
-<script src="/static/js/gen/setting.min.46f9044b63239b7aa911.js"></script>
+<script src="/static/js/gen/setting.min.1faeb808b925ee3acc5c.js"></script>
 
 {% endblock %}
 

--- a/templates/projects/summary.webpack.ejs
+++ b/templates/projects/summary.webpack.ejs
@@ -37,7 +37,7 @@
                     <fields-config></fields-config>
                 </div>
                 <div>
-                    <consensus-config></consensus-config>
+                    <redundancy-config></redundancy-config>
                 </div>
             </div>
         </div>

--- a/templates/projects/summary.webpack.ejs
+++ b/templates/projects/summary.webpack.ejs
@@ -9,6 +9,7 @@
         <li role="presentation"><a href="#task" aria-controls="task" role="tab" data-toggle="tab">Task</a></li>
         <li role="presentation"><a href="#answer" aria-controls="answer" role="tab" data-toggle="tab">Answer</a></li>
         <li role="presentation"><a href="#quiz" aria-controls="quiz" role="tab" data-toggle="tab">Quiz</a></li>
+        <li role="presentation"><a href="#consensus" aria-controls="consensus" role="tab" data-toggle="tab">Consensus</a></li>
     </ul>
     <br>
 
@@ -47,6 +48,16 @@
                 <div class="row">
                     <div class="col-sm-12">
                         <quiz-setting></quiz-setting>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div role="tabpanel" class="tab-pane fade" id="consensus">
+            <div class="col-md-12">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <consensus-setting></consensus-setting>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-6334*

### Changes
 - refactor existing `ConsensusConfig` component to `RedundancyConfig`
 - add new `ConsensusConfig` component
    - responsive settings based on which consensus method is chosen
 - Add new tab 'Consensus' for task level consensus settings
 - Add UI headers in 'project settings -> Answer' for Answer field config and Redundancy Config

### Consensus Fields Breakdown:
 - Consensus Method: how to calculate consensus
    - options: F1, Jaccard, Dice, Overlap, Majority
 - Agreement threshold: what percentage of the two answers must match for agreement (pairwise comparison)
 - Consensus threshold: what total percentage of answers need to match for there to be consensus or not
    - Determines if redundancy will be updated
   
![mockup-3](https://github.com/Scifabric/pybossa-default-theme/assets/17805819/62dac1c4-a567-4aef-979c-8bd757d64856)

example project:

```
{
  "id": 1,
  "created": "2024-04-25T19:50:45.592631",
  "updated": "2024-05-06T15:14:15.176278",
  "name": "Location Pref Test",
  "short_name": "locationpreftest",
  "description": "test location pref",
  "long_description": "test location pref",
  "answer_fields": {
    "test": {
      "type": "categorical",
      "config": {
        "labels": []
      },
      "retry_for_consensus": true
    }
  },
  "reserve_tasks": {
    "category": []
  },
  "consensus_config": {
    "max_retries": 10,
    "consensus_method": "jaccard",
    "redundancy_config": 1,
    "agreement_threshold": 75,
    "consensus_threshold": 51
  }
}
```