### PR TITLE
answerfieldsconfig Bugfix

### DIFF
--- a/templates/projects/answerfieldsconfig.html
+++ b/templates/projects/answerfieldsconfig.html
@@ -13,18 +13,18 @@
             <fields-config > </fields-config>
         </div>
         <div>
-            <redundancy-config :redundancy-config="{{redundancy_config}}"></redundancy-config>
+            <redundancy-config :redundancy-config="{{consensus_config}}"></redundancy-config>
         </div>
     </div>
 </div>
 
-<script src="/static/js/gen/answerfieldsconfig.min.1faeb808b925ee3acc5c.js"></script>
+<script src="/static/js/gen/answerfieldsconfig.min.de95e17d9e066e2e3aa3.js"></script>
 
 <script>
 answerFields.setData({
     csrf: '{{csrf}}',
     answerFields: {{answer_fields | safe}},
-    consensus: {{redundancy_config | safe}}
+    consensus: {{consensus_config | safe}}
 });
 </script>
 {% endblock %}

--- a/templates/projects/answerfieldsconfig.webpack.ejs
+++ b/templates/projects/answerfieldsconfig.webpack.ejs
@@ -13,7 +13,7 @@
             <fields-config > </fields-config>
         </div>
         <div>
-            <redundancy-config :redundancy-config="{{redundancy_config}}"></redundancy-config>
+            <redundancy-config :redundancy-config="{{consensus_config}}"></redundancy-config>
         </div>
     </div>
 </div>
@@ -24,7 +24,7 @@
 answerFields.setData({
     csrf: '{{csrf}}',
     answerFields: {{answer_fields | safe}},
-    consensus: {{redundancy_config | safe}}
+    consensus: {{consensus_config | safe}}
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
 - fix bug where `project/[project_shortname]/answerfieldsconfig` does not load form

**Additional Context:**
https://github.com/bloomberg/pybossa-default-theme/pull/454
answer consensus configuration was previously split into 2 elements, `consensus-config` and `redundancy-config`. Backend still represents them as one object, `consensus_config`. To be cleaned once we build out backend

JIRA for future cleanup: https://jira.prod.bloomberg.com/browse/RDISCROWD-7377