### PR TITLE
RDISCROWD-7841 - fix loading icon hanging

### DIFF
--- a/static/src/components/setting/index.vue
+++ b/static/src/components/setting/index.vue
@@ -248,7 +248,7 @@ export default {
       const users = isIds ? usersOrIds.map(id => this.users[id]) : usersOrIds;
 
       // Sort the users by their last name.
-      return users.slice().sort((a, b) => {
+      return users.filter(u => u).slice().sort((a, b) => {
         return a.last_name.localeCompare(b.last_name, undefined, { sensitivity: 'base' });
       });
     },


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-7841*

Bug:
`users` array contains `undefined` values and causes page to hang. 

Solution:
filter out `undefined` values.