### PR TITLE
RDISCROWD-7779-3 fix form helper key error

### DIFF
--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -33,7 +33,7 @@
     {% endfor %}
 {%- endmacro %}
 
-{% macro render_select2_field(field, tooltip=None, config={ placeholder: "Select multiple" }) -%}
+{% macro render_select2_field(field, tooltip=None, config={ "placeholder": "Select multiple" }) -%}
      <div class="form-group {% if field.errors %}has-error{% endif %} {% if field.flags.required %}required{% endif %} {{ kwargs.pop('class_', '') }}">
         <style>
             .select2-selection {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #RDISCROWD-7779*

Fixes this error in tests:
```
    /opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/json/encoder.py line 257 in iterencode
      return _iterencode(o, 0)
   TypeError: keys must be str, int, float, bool or None, not Undefined
   ```
